### PR TITLE
fix: Close My Mini Apps section by default

### DIFF
--- a/components/MiniAppTab.js
+++ b/components/MiniAppTab.js
@@ -307,7 +307,7 @@ export default function MiniAppTab({ pubkey, onLogout }) {
 
   // My Mini Apps state
   const [favoriteApps, setFavoriteApps] = useState([])
-  const [showMyApps, setShowMyApps] = useState(true)
+  const [showMyApps, setShowMyApps] = useState(false)
   const [externalAppUrl, setExternalAppUrl] = useState('')
   const [externalAppName, setExternalAppName] = useState('')
   const [draggedIndex, setDraggedIndex] = useState(null)


### PR DESCRIPTION
Changed showMyApps initial state from true to false to have the My Mini Apps section collapsed by default, improving initial page clarity and reducing visual clutter.