### PR TITLE
fix: Reduce concurrent requests and handle SSL/TLS errors

### DIFF
--- a/components/BadgeDisplay.js
+++ b/components/BadgeDisplay.js
@@ -124,7 +124,7 @@ export default function BadgeDisplay({ pubkey, maxBadges = 3 }) {
     try {
       const currentRelay = getDefaultRelay()
       // Use multiple relays for better badge definition coverage
-      const extraRelays = ['wss://yabu.me', 'wss://relay.damus.io', 'wss://relay.nostr.band', 'wss://nos.lol']
+      const extraRelays = ['wss://yabu.me', 'wss://relay.damus.io', 'wss://nos.lol']
       const allRelays = [...new Set([currentRelay, ...extraRelays])]
       
       // Fetch profile badges (kind 30008) - try multiple relays

--- a/components/MiniAppTab.js
+++ b/components/MiniAppTab.js
@@ -248,7 +248,6 @@ const KNOWN_RELAYS = [
   { url: 'wss://r.kojira.io', name: 'Kojira', region: 'JP' },
   { url: 'wss://nos.lol', name: 'nos.lol', region: 'Global' },
   { url: 'wss://relay.damus.io', name: 'Damus', region: 'Global' },
-  { url: 'wss://relay.nostr.band', name: 'nostr.band', region: 'Global' },
   { url: 'wss://relay.snort.social', name: 'Snort', region: 'Global' },
   { url: 'wss://nostr.wine', name: 'nostr.wine (有料)', region: 'Global' },
   { url: 'wss://relay.nostr.bg', name: 'nostr.bg', region: 'EU' },
@@ -420,7 +419,7 @@ export default function MiniAppTab({ pubkey, onLogout }) {
       const currentRelay = getDefaultRelay()
       // Use multiple relays for better coverage (Japanese relays first)
       const relays = [currentRelay]
-      const extraRelays = ['wss://yabu.me', 'wss://relay-jp.nostr.wirednet.jp', 'wss://r.kojira.io', 'wss://relay.nostr.band', 'wss://nos.lol']
+      const extraRelays = ['wss://yabu.me', 'wss://relay-jp.nostr.wirednet.jp', 'wss://r.kojira.io', 'wss://nos.lol']
       const allRelays = [...new Set([currentRelay, ...extraRelays])]
       
       // Load current profile badges (kind 30008)

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -15,10 +15,10 @@ import { SimplePool } from 'nostr-tools/pool'
 // Configuration
 const CONFIG = {
   // Maximum concurrent requests across all operations
-  maxConcurrentRequests: 5,
+  maxConcurrentRequests: 4,
 
-  // Maximum concurrent requests per relay
-  maxRequestsPerRelay: 3,
+  // Maximum concurrent requests per relay (reduced to prevent relay overload)
+  maxRequestsPerRelay: 2,
 
   // Request timeout in ms
   requestTimeout: 15000,
@@ -70,7 +70,10 @@ const requestQueue = {
 const rateLimiters = new Map()
 
 // Failed relay tracking
-const failedRelays = new Map() // relay -> { failures: number, lastFailure: timestamp }
+const failedRelays = new Map() // relay -> { failures: number, lastFailure: timestamp, sslError: boolean }
+
+// Permanently disabled relays (e.g., SSL/TLS errors)
+const disabledRelays = new Set()
 
 /**
  * Token bucket rate limiter for each relay
@@ -121,9 +124,28 @@ function getRateLimiter(relay) {
 }
 
 /**
- * Check if a relay is in cooldown due to repeated failures
+ * Check if an error is SSL/TLS related
+ */
+function isSSLError(error) {
+  if (!error) return false
+  const message = error.message || error.toString() || ''
+  const lowerMessage = message.toLowerCase()
+
+  return lowerMessage.includes('ssl') ||
+         lowerMessage.includes('tls') ||
+         lowerMessage.includes('certificate') ||
+         lowerMessage.includes('cert_') ||
+         lowerMessage.includes('handshake') ||
+         lowerMessage.includes('secure connection')
+}
+
+/**
+ * Check if a relay is in cooldown due to repeated failures or permanently disabled
  */
 function isRelayInCooldown(relay) {
+  // Check if permanently disabled (SSL/TLS errors)
+  if (disabledRelays.has(relay)) return true
+
   const failureInfo = failedRelays.get(relay)
   if (!failureInfo) return false
 
@@ -142,11 +164,22 @@ function isRelayInCooldown(relay) {
 /**
  * Record a relay failure
  */
-function recordRelayFailure(relay) {
+function recordRelayFailure(relay, error = null) {
+  // Check for SSL/TLS errors - permanently disable the relay
+  if (error && isSSLError(error)) {
+    disabledRelays.add(relay)
+    console.warn(`[Connection Manager] Relay ${relay} permanently disabled due to SSL/TLS error:`, error.message)
+    return
+  }
+
   const failureInfo = failedRelays.get(relay) || { failures: 0, lastFailure: 0 }
   failureInfo.failures++
   failureInfo.lastFailure = Date.now()
   failedRelays.set(relay, failureInfo)
+
+  if (failureInfo.failures >= CONFIG.maxFailuresBeforeCooldown) {
+    console.warn(`[Connection Manager] Relay ${relay} in cooldown after ${failureInfo.failures} failures`)
+  }
 }
 
 /**
@@ -377,8 +410,8 @@ export async function executeWithRetry(queryFn, relays, options = {}) {
     } catch (e) {
       lastError = e
 
-      // Record failure
-      recordRelayFailure(relay)
+      // Record failure with error details for SSL/TLS detection
+      recordRelayFailure(relay, e)
 
       // Don't retry on abort
       if (e.name === 'AbortError') {
@@ -540,6 +573,7 @@ export function getConnectionStats() {
     relayPending: Object.fromEntries(requestQueue.relayPending),
     rateLimiters: rateLimiters.size,
     failedRelays: Object.fromEntries(failedRelays),
+    disabledRelays: Array.from(disabledRelays),
     poolActive: pool !== null && !isClosing,
     lastUsed: poolLastUsed,
     idleTime: Date.now() - poolLastUsed,


### PR DESCRIPTION
- Reduce maxRequestsPerRelay from 3 to 2 to prevent relay overload
- Add SSL/TLS error detection to permanently disable problematic relays
- Remove relay.nostr.band from relay lists (SSL certificate expired)
- Add disabledRelays tracking to connection statistics

Fixes the "too many concurrent REQs" errors from yabu.me and prevents repeated connection attempts to relays with SSL/TLS issues.