### PR TITLE
fix: Improve CORS error handling and image loading

### DIFF
--- a/components/MiniAppTab.js
+++ b/components/MiniAppTab.js
@@ -1513,7 +1513,16 @@ export default function MiniAppTab({ pubkey, onLogout }) {
                               <div className="flex items-center gap-2 min-w-0">
                                 <div className="w-8 h-8 rounded-full overflow-hidden bg-[var(--bg-primary)] flex-shrink-0">
                                   {profile?.picture ? (
-                                    <img src={profile.picture} alt="" className="w-full h-full object-cover" />
+                                    <img
+                                      src={profile.picture}
+                                      alt=""
+                                      className="w-full h-full object-cover"
+                                      referrerPolicy="no-referrer"
+                                      onError={(e) => {
+                                        e.target.style.display = 'none'
+                                        e.target.parentElement.innerHTML = '<div class="w-full h-full flex items-center justify-center"><svg class="w-4 h-4 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>'
+                                      }}
+                                    />
                                   ) : (
                                     <div className="w-full h-full flex items-center justify-center">
                                       <svg className="w-4 h-4 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor">

--- a/components/PostItem.js
+++ b/components/PostItem.js
@@ -143,7 +143,16 @@ function EmbeddedNote({ noteId, relays }) {
       <div className="flex items-center gap-2 mb-1.5">
         <div className="w-5 h-5 rounded-full overflow-hidden bg-[var(--bg-tertiary)] flex-shrink-0">
           {profile?.picture ? (
-            <img src={profile.picture} alt="" className="w-full h-full object-cover" />
+            <img
+              src={profile.picture}
+              alt=""
+              className="w-full h-full object-cover"
+              referrerPolicy="no-referrer"
+              onError={(e) => {
+                e.target.style.display = 'none'
+                e.target.parentElement.innerHTML = '<div class="w-full h-full flex items-center justify-center"><svg class="w-3 h-3 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>'
+              }}
+            />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
               <svg className="w-3 h-3 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor">
@@ -542,10 +551,15 @@ export default function PostItem({
           className="w-10 h-10 lg:w-12 lg:h-12 rounded-full overflow-hidden bg-[var(--bg-tertiary)] flex-shrink-0 hover:opacity-80 transition-opacity"
         >
           {displayProfile?.picture ? (
-            <img 
-              src={displayProfile.picture} 
-              alt="" 
+            <img
+              src={displayProfile.picture}
+              alt=""
               className="w-full h-full object-cover"
+              referrerPolicy="no-referrer"
+              onError={(e) => {
+                e.target.style.display = 'none'
+                e.target.parentElement.innerHTML = '<div class="w-full h-full flex items-center justify-center"><svg class="w-5 h-5 lg:w-6 lg:h-6 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>'
+              }}
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">

--- a/components/SchedulerApp.js
+++ b/components/SchedulerApp.js
@@ -634,11 +634,15 @@ function EventDetailModal({ event, allEvents = [], rsvps, profiles, myPubkey, on
           {/* Creator */}
           <div className="flex items-center gap-2 mt-2">
             {profiles[event.pubkey]?.picture ? (
-              <img 
-                src={profiles[event.pubkey].picture} 
-                alt="" 
+              <img
+                src={profiles[event.pubkey].picture}
+                alt=""
                 className="w-6 h-6 rounded-full"
                 referrerPolicy="no-referrer"
+                onError={(e) => {
+                  e.target.style.display = 'none'
+                  e.target.parentElement.innerHTML = '<div class="w-6 h-6 rounded-full bg-[var(--bg-tertiary)]" />'
+                }}
               />
             ) : (
               <div className="w-6 h-6 rounded-full bg-[var(--bg-tertiary)]" />
@@ -727,7 +731,16 @@ function EventDetailModal({ event, allEvents = [], rsvps, profiles, myPubkey, on
                           <td className="p-3 border-r border-[var(--border-color)] bg-[var(--bg-primary)]">
                             <div className="flex items-center gap-2">
                               {profile?.picture ? (
-                                <img src={profile.picture} alt="" className="w-5 h-5 rounded-full flex-shrink-0" referrerPolicy="no-referrer" />
+                                <img
+                                  src={profile.picture}
+                                  alt=""
+                                  className="w-5 h-5 rounded-full flex-shrink-0"
+                                  referrerPolicy="no-referrer"
+                                  onError={(e) => {
+                                    e.target.style.display = 'none'
+                                    e.target.parentElement.innerHTML += '<div class="w-5 h-5 rounded-full bg-[var(--bg-tertiary)] flex-shrink-0" />'
+                                  }}
+                                />
                               ) : (
                                 <div className="w-5 h-5 rounded-full bg-[var(--bg-tertiary)] flex-shrink-0" />
                               )}
@@ -995,11 +1008,15 @@ function EventCard({ event, allEvents = [], rsvps, profiles, myPubkey, onViewDet
     >
       <div className="flex items-center gap-2 mb-2">
         {creatorProfile?.picture ? (
-          <img 
-            src={creatorProfile.picture} 
-            alt="" 
+          <img
+            src={creatorProfile.picture}
+            alt=""
             className="w-6 h-6 rounded-full object-cover"
             referrerPolicy="no-referrer"
+            onError={(e) => {
+              e.target.style.display = 'none'
+              e.target.parentElement.innerHTML += '<div class="w-6 h-6 rounded-full bg-[var(--bg-secondary)]" />'
+            }}
           />
         ) : (
           <div className="w-6 h-6 rounded-full bg-[var(--bg-secondary)]" />

--- a/components/UserProfileView.js
+++ b/components/UserProfileView.js
@@ -590,7 +590,16 @@ export default function UserProfileView({
               <div className="relative -mt-10">
                 <div className="w-20 h-20 rounded-full overflow-hidden border-4 border-[var(--bg-primary)] bg-[var(--bg-tertiary)]">
                   {profile?.picture ? (
-                    <img src={profile.picture} alt="" className="w-full h-full object-cover" />
+                    <img
+                      src={profile.picture}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.target.style.display = 'none'
+                        e.target.parentElement.innerHTML = '<div class="w-full h-full flex items-center justify-center"><svg class="w-10 h-10 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>'
+                      }}
+                    />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center">
                       <svg className="w-10 h-10 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor">

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -1078,21 +1078,40 @@ export async function verifyNip05(nip05, pubkey) {
   try {
     const [name, domain] = normalizedNip05.split('@')
     if (!name || !domain) return false
-    
+
     const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`
-    const response = await fetch(url)
-    if (!response.ok) return false
-    
-    const data = await response.json()
-    const verified = data.names?.[name]?.toLowerCase() === pubkey.toLowerCase()
-    
-    // Cache result for 5 minutes
-    nip05Cache.set(cacheKey, verified)
-    setTimeout(() => nip05Cache.delete(cacheKey), 5 * 60 * 1000)
-    
-    return verified
+
+    // Fetch with timeout and explicit CORS mode
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        mode: 'cors',
+        credentials: 'omit',
+        referrerPolicy: 'no-referrer'
+      })
+      clearTimeout(timeoutId)
+
+      if (!response.ok) return false
+
+      const data = await response.json()
+      const verified = data.names?.[name]?.toLowerCase() === pubkey.toLowerCase()
+
+      // Cache result for 5 minutes
+      nip05Cache.set(cacheKey, verified)
+      setTimeout(() => nip05Cache.delete(cacheKey), 5 * 60 * 1000)
+
+      return verified
+    } catch (fetchError) {
+      clearTimeout(timeoutId)
+      // Silently ignore CORS errors, timeouts, and other fetch failures
+      // These errors are logged by the browser but cannot be suppressed
+      return false
+    }
   } catch (e) {
-    // Silently ignore verification failures (CORS, network, etc)
+    // Silently ignore verification failures (invalid format, etc)
     return false
   }
 }


### PR DESCRIPTION
- Add timeout (5s) to NIP-05 verification fetch
- Add referrerPolicy="no-referrer" to all profile images
- Add onError handlers to gracefully fallback to default avatars
- Improve fetch options: explicit CORS mode, credentials omit

This reduces browser console CORS errors and prevents image loading failures from breaking the UI. While CORS errors cannot be completely suppressed by client-side code, these changes minimize their impact and provide better fallback handling.