### PR TITLE
feat: 地域選択によるリレー自動設定機能の追加

### DIFF
--- a/lib/geohash.js
+++ b/lib/geohash.js
@@ -571,3 +571,142 @@ export function formatDistance(km) {
     return `${Math.round(km)}km`
   }
 }
+
+// ============================================
+// Region Selection (for users who don't want to share GPS)
+// ============================================
+
+/**
+ * Predefined regions with representative coordinates
+ * Users can select their region manually instead of sharing GPS
+ */
+export const REGION_COORDINATES = [
+  // Japan regions
+  { id: 'jp-tokyo', name: '東京', nameEn: 'Tokyo', lat: 35.6762, lon: 139.6503, country: 'JP' },
+  { id: 'jp-osaka', name: '大阪', nameEn: 'Osaka', lat: 34.6937, lon: 135.5023, country: 'JP' },
+  { id: 'jp-nagoya', name: '名古屋', nameEn: 'Nagoya', lat: 35.1815, lon: 136.9066, country: 'JP' },
+  { id: 'jp-fukuoka', name: '福岡', nameEn: 'Fukuoka', lat: 33.5904, lon: 130.4017, country: 'JP' },
+  { id: 'jp-sapporo', name: '札幌', nameEn: 'Sapporo', lat: 43.0618, lon: 141.3545, country: 'JP' },
+
+  // Asia
+  { id: 'sg', name: 'シンガポール', nameEn: 'Singapore', lat: 1.3521, lon: 103.8198, country: 'SG' },
+  { id: 'tw', name: '台湾', nameEn: 'Taiwan', lat: 25.0330, lon: 121.5654, country: 'TW' },
+  { id: 'kr', name: '韓国', nameEn: 'South Korea', lat: 37.5665, lon: 126.9780, country: 'KR' },
+  { id: 'cn-shanghai', name: '上海', nameEn: 'Shanghai', lat: 31.2304, lon: 121.4737, country: 'CN' },
+  { id: 'in', name: 'インド', nameEn: 'India', lat: 28.6139, lon: 77.2090, country: 'IN' },
+
+  // North America
+  { id: 'us-west', name: '北米西部', nameEn: 'US West', lat: 37.7749, lon: -122.4194, country: 'US' },
+  { id: 'us-east', name: '北米東部', nameEn: 'US East', lat: 40.7128, lon: -74.0060, country: 'US' },
+  { id: 'ca', name: 'カナダ', nameEn: 'Canada', lat: 43.6532, lon: -79.3832, country: 'CA' },
+
+  // Europe
+  { id: 'eu-west', name: '西ヨーロッパ', nameEn: 'Western Europe', lat: 48.8566, lon: 2.3522, country: 'EU' },
+  { id: 'eu-central', name: '中央ヨーロッパ', nameEn: 'Central Europe', lat: 52.5200, lon: 13.4050, country: 'EU' },
+  { id: 'eu-north', name: '北ヨーロッパ', nameEn: 'Northern Europe', lat: 59.3293, lon: 18.0686, country: 'EU' },
+  { id: 'uk', name: 'イギリス', nameEn: 'UK', lat: 51.5074, lon: -0.1278, country: 'UK' },
+
+  // Others
+  { id: 'au', name: 'オーストラリア', nameEn: 'Australia', lat: -33.8688, lon: 151.2093, country: 'AU' },
+  { id: 'br', name: 'ブラジル', nameEn: 'Brazil', lat: -23.5505, lon: -46.6333, country: 'BR' },
+  { id: 'global', name: 'グローバル', nameEn: 'Global', lat: 0, lon: 0, country: 'Global' },
+]
+
+/**
+ * Save selected region to localStorage
+ * @param {string} regionId
+ */
+export function saveSelectedRegion(regionId) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('selected_region', regionId)
+  }
+}
+
+/**
+ * Load selected region from localStorage
+ * @returns {string|null}
+ */
+export function loadSelectedRegion() {
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem('selected_region')
+  }
+  return null
+}
+
+/**
+ * Get region by ID
+ * @param {string} regionId
+ * @returns {Object|null}
+ */
+export function getRegionById(regionId) {
+  return REGION_COORDINATES.find(r => r.id === regionId) || null
+}
+
+/**
+ * Generate relay configuration based on selected region
+ * Similar to autoDetectRelays but uses predefined region coordinates
+ * @param {string} regionId - Region ID from REGION_COORDINATES
+ * @returns {{geohash: string, relays: Array, location: {lat: number, lon: number}, nip65Config: Object, nearestRelays: Array, region: Object}}
+ */
+export function selectRelaysByRegion(regionId) {
+  const region = getRegionById(regionId)
+  if (!region) {
+    return {
+      geohash: null,
+      relays: REGIONAL_RELAYS.default,
+      location: null,
+      nip65Config: null,
+      nearestRelays: null,
+      region: null,
+      error: 'Unknown region'
+    }
+  }
+
+  // Global region uses default relays
+  if (regionId === 'global') {
+    const globalRelays = GPS_RELAY_DATABASE
+      .filter(r => r.priority === 1)
+      .slice(0, 10)
+      .map(r => ({ ...r, distance: 0 }))
+
+    return {
+      geohash: 'global',
+      relays: REGIONAL_RELAYS.default,
+      location: { lat: 0, lon: 0 },
+      nip65Config: {
+        inbox: globalRelays.slice(0, 4),
+        outbox: globalRelays.slice(0, 5),
+        discover: DIRECTORY_RELAYS.map(r => ({ ...r, distance: 0 })),
+        combined: globalRelays.slice(0, 5).map(r => ({ url: r.url, read: true, write: true }))
+      },
+      nearestRelays: globalRelays,
+      region
+    }
+  }
+
+  const { lat, lon } = region
+  const geohash = encodeGeohash(lat, lon, 5)
+
+  // Save to localStorage
+  saveSelectedRegion(regionId)
+  saveUserGeohash(geohash)
+  saveUserLocation(lat, lon)
+
+  // Get relays by geohash
+  const relays = getRelaysByGeohash(geohash)
+
+  // Generate NIP-65 configuration
+  const nip65Config = generateRelayListByLocation(lat, lon)
+
+  // Find nearest relays
+  const nearestRelays = findNearestRelays(lat, lon, 10)
+
+  return {
+    geohash,
+    relays,
+    location: { lat, lon },
+    nip65Config,
+    nearestRelays,
+    region
+  }
+}


### PR DESCRIPTION
- GPS共有が不要な地域選択UI（ドロップダウン）を追加
- REGION_COORDINATES: 日本5地域、アジア5地域、北米3地域、欧州4地域、その他3地域
- 「使用中のリレー」→「地域」表示に変更
- 地域選択でジオハッシュ生成・NIP-65リレーリスト自動作成
- 最寄りリレークリックでNIP-65設定も更新されるように修正

https://claude.ai/code/session_01UeuUZeky89PXknWwiZCebC