### PR TITLE
fix: useNostrSubscriptionの無限ループ修正とNIP-05 CORSプロキシ追加

### DIFF
--- a/app/api/nip05/route.js
+++ b/app/api/nip05/route.js
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * NIP-05 proxy endpoint to avoid CORS issues
+ * GET /api/nip05?domain=example.com&name=user
+ */
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const domain = searchParams.get('domain')
+  const name = searchParams.get('name')
+
+  if (!domain || !name) {
+    return NextResponse.json(
+      { error: 'Missing domain or name parameter' },
+      { status: 400 }
+    )
+  }
+
+  // Validate domain to prevent SSRF
+  const domainRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*(\.[a-zA-Z0-9][a-zA-Z0-9-]*)*$/
+  if (!domainRegex.test(domain)) {
+    return NextResponse.json(
+      { error: 'Invalid domain format' },
+      { status: 400 }
+    )
+  }
+
+  const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`
+
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': 'Null-Nostr/1.0'
+      }
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Upstream returned ${response.status}` },
+        { status: response.status }
+      )
+    }
+
+    const data = await response.json()
+
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': 'public, max-age=300' // Cache for 5 minutes
+      }
+    })
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'Request timeout' },
+        { status: 504 }
+      )
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to fetch NIP-05 data' },
+      { status: 502 }
+    )
+  }
+}

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -1071,36 +1071,33 @@ const nip05Cache = new Map()
 
 export async function verifyNip05(nip05, pubkey) {
   if (!nip05 || !pubkey) return false
-  
+
   // Normalize NIP-05 format
   let normalizedNip05 = nip05
   if (!nip05.includes('@')) {
     // Domain only format - treat as _@domain
     normalizedNip05 = `_@${nip05}`
   }
-  
+
   // Check cache
   const cacheKey = `${normalizedNip05}:${pubkey}`
   if (nip05Cache.has(cacheKey)) {
     return nip05Cache.get(cacheKey)
   }
-  
+
   try {
     const [name, domain] = normalizedNip05.split('@')
     if (!name || !domain) return false
 
-    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`
+    // Use proxy to avoid CORS issues
+    const proxyUrl = `/api/nip05?domain=${encodeURIComponent(domain)}&name=${encodeURIComponent(name)}`
 
-    // Fetch with timeout and explicit CORS mode
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
+    const timeoutId = setTimeout(() => controller.abort(), 5000)
 
     try {
-      const response = await fetch(url, {
-        signal: controller.signal,
-        mode: 'cors',
-        credentials: 'omit',
-        referrerPolicy: 'no-referrer'
+      const response = await fetch(proxyUrl, {
+        signal: controller.signal
       })
       clearTimeout(timeoutId)
 
@@ -1116,12 +1113,9 @@ export async function verifyNip05(nip05, pubkey) {
       return verified
     } catch (fetchError) {
       clearTimeout(timeoutId)
-      // Silently ignore CORS errors, timeouts, and other fetch failures
-      // These errors are logged by the browser but cannot be suppressed
       return false
     }
   } catch (e) {
-    // Silently ignore verification failures (invalid format, etc)
     return false
   }
 }
@@ -1141,18 +1135,15 @@ export async function resolveNip05(nip05) {
     const [name, domain] = normalizedNip05.split('@')
     if (!name || !domain) return null
 
-    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`
+    // Use proxy to avoid CORS issues
+    const proxyUrl = `/api/nip05?domain=${encodeURIComponent(domain)}&name=${encodeURIComponent(name)}`
 
-    // Fetch with timeout and explicit CORS mode
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 5000)
 
     try {
-      const response = await fetch(url, {
-        signal: controller.signal,
-        mode: 'cors',
-        credentials: 'omit',
-        referrerPolicy: 'no-referrer'
+      const response = await fetch(proxyUrl, {
+        signal: controller.signal
       })
       clearTimeout(timeoutId)
 


### PR DESCRIPTION
- useNostrSubscriptionのコールバック関数をuseRefで保持し、 依存配列から除外することで、画面更新時の不要な再購読を防止
- NIP-05検証用のAPI Route（/api/nip05）を追加し、 CORS制限のあるサーバーからもNIP-05情報を取得可能に