### PR TITLE
fix: output:exportを条件付きに変更してVercelビルド修正

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,14 @@
 /** @type {import('next').NextConfig} */
+const isCapacitorBuild = process.env.CAPACITOR_BUILD === 'true'
+
 const nextConfig = {
   reactStrictMode: true,
-  output: 'export', // Required for Capacitor
+  // output: 'export' is only enabled for Capacitor builds
+  // Vercel deployments need dynamic API routes (e.g., /api/nip05)
+  ...(isCapacitorBuild && { output: 'export' }),
   trailingSlash: true,
   images: {
-    unoptimized: true, // Required for static export
+    unoptimized: true, // Required for static export and simpler image handling
     remotePatterns: [
       {
         protocol: 'https',
@@ -12,23 +16,26 @@ const nextConfig = {
       },
     ],
   },
-  async headers() {
-    return [
-      {
-        source: '/sw.js',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-cache, no-store, must-revalidate',
-          },
-          {
-            key: 'Service-Worker-Allowed',
-            value: '/',
-          },
-        ],
-      },
-    ]
-  },
+  // Note: headers() only works when NOT using output: 'export'
+  ...(!isCapacitorBuild && {
+    async headers() {
+      return [
+        {
+          source: '/sw.js',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: 'no-cache, no-store, must-revalidate',
+            },
+            {
+              key: 'Service-Worker-Allowed',
+              value: '/',
+            },
+          ],
+        },
+      ]
+    },
+  }),
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
- CAPACITOR_BUILD環境変数がtrueの時のみoutput: 'export'を有効化
- Vercelでは動的API Routes (/api/nip05) が正常に動作するように
- headers()もoutput: 'export'と競合するため条件付きに

https://claude.ai/code/session_017K2yBYNhKcxyF4e2WQBGnQ