### PR TITLE
feat: Phase 2 状態管理の統一 (Zustand Store)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,15 @@
         "@capacitor/app": "^8.0.0",
         "@capacitor/cli": "^8.0.0",
         "@capacitor/core": "^8.0.0",
+        "immer": "^11.1.3",
         "next": "14.2.35",
         "nosskey-sdk": "^0.0.4",
         "nostr-tools": "^2.17.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "rx-nostr": "^3.6.2",
-        "rxjs": "^7.8.2"
+        "rxjs": "^7.8.2",
+        "zustand": "^5.0.10"
       },
       "devDependencies": {
         "@types/react": "19.2.10",
@@ -672,7 +674,7 @@
       "version": "19.2.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1074,7 +1076,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1347,6 +1349,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/inherits": {
@@ -2976,6 +2988,35 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
+      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "@capacitor/app": "^8.0.0",
     "@capacitor/cli": "^8.0.0",
     "@capacitor/core": "^8.0.0",
+    "immer": "^11.1.3",
     "next": "14.2.35",
     "nosskey-sdk": "^0.0.4",
     "nostr-tools": "^2.17.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "rx-nostr": "^3.6.2",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@types/react": "19.2.10",

--- a/src/core/store/hooks.ts
+++ b/src/core/store/hooks.ts
@@ -1,0 +1,209 @@
+/**
+ * Store Hooks
+ *
+ * React hooks for accessing the Zustand store with memoization
+ *
+ * @module core/store/hooks
+ */
+
+import { useStore } from './index'
+import type { Profile, LoginMethod } from './types'
+
+// ====================================
+// Auth Hooks
+// ====================================
+
+/**
+ * Get auth state
+ */
+export function useAuth() {
+  return useStore((state) => ({
+    pubkey: state.pubkey,
+    loginMethod: state.loginMethod,
+    isLoggedIn: state.isLoggedIn,
+  }))
+}
+
+/**
+ * Get current user's pubkey
+ */
+export function usePubkey(): string | null {
+  return useStore((state) => state.pubkey)
+}
+
+/**
+ * Get login method
+ */
+export function useLoginMethod(): LoginMethod | null {
+  return useStore((state) => state.loginMethod)
+}
+
+/**
+ * Check if user is logged in
+ */
+export function useIsLoggedIn(): boolean {
+  return useStore((state) => state.isLoggedIn)
+}
+
+/**
+ * Get auth actions
+ */
+export function useAuthActions() {
+  return useStore((state) => ({
+    login: state.login,
+    logout: state.logout,
+    setPubkey: state.setPubkey,
+  }))
+}
+
+// ====================================
+// Settings Hooks
+// ====================================
+
+/**
+ * Get all settings
+ */
+export function useSettings() {
+  return useStore((state) => ({
+    defaultZapAmount: state.defaultZapAmount,
+    lowBandwidthMode: state.lowBandwidthMode,
+    autoSign: state.autoSign,
+    userGeohash: state.userGeohash,
+    customRelays: state.customRelays,
+    mutedPubkeys: state.mutedPubkeys,
+    mutedWords: state.mutedWords,
+  }))
+}
+
+/**
+ * Get default zap amount
+ */
+export function useDefaultZapAmount(): number {
+  return useStore((state) => state.defaultZapAmount)
+}
+
+/**
+ * Get low bandwidth mode setting
+ */
+export function useLowBandwidthMode(): boolean {
+  return useStore((state) => state.lowBandwidthMode)
+}
+
+/**
+ * Get auto sign setting
+ */
+export function useAutoSign(): boolean {
+  return useStore((state) => state.autoSign)
+}
+
+/**
+ * Get user geohash
+ */
+export function useUserGeohash(): string | null {
+  return useStore((state) => state.userGeohash)
+}
+
+/**
+ * Get custom relays
+ */
+export function useCustomRelays(): string[] {
+  return useStore((state) => state.customRelays)
+}
+
+/**
+ * Get muted pubkeys
+ */
+export function useMutedPubkeys(): string[] {
+  return useStore((state) => state.mutedPubkeys)
+}
+
+/**
+ * Get muted words
+ */
+export function useMutedWords(): string[] {
+  return useStore((state) => state.mutedWords)
+}
+
+/**
+ * Get settings actions
+ */
+export function useSettingsActions() {
+  return useStore((state) => ({
+    setDefaultZapAmount: state.setDefaultZapAmount,
+    setLowBandwidthMode: state.setLowBandwidthMode,
+    setAutoSign: state.setAutoSign,
+    setUserGeohash: state.setUserGeohash,
+    addCustomRelay: state.addCustomRelay,
+    removeCustomRelay: state.removeCustomRelay,
+    setCustomRelays: state.setCustomRelays,
+    addMutedPubkey: state.addMutedPubkey,
+    removeMutedPubkey: state.removeMutedPubkey,
+    addMutedWord: state.addMutedWord,
+    removeMutedWord: state.removeMutedWord,
+  }))
+}
+
+// ====================================
+// Cache Hooks
+// ====================================
+
+/**
+ * Get a cached profile
+ */
+export function useCachedProfile(pubkey: string): Profile | undefined {
+  return useStore((state) => state.getProfile(pubkey))
+}
+
+/**
+ * Get follow list for a pubkey
+ */
+export function useFollowList(pubkey: string | null): string[] | undefined {
+  return useStore((state) =>
+    pubkey ? state.getFollowList(pubkey) : undefined
+  )
+}
+
+/**
+ * Get current user's follow list
+ */
+export function useMyFollowList(): string[] | undefined {
+  const pubkey = usePubkey()
+  return useFollowList(pubkey)
+}
+
+/**
+ * Get cache actions
+ */
+export function useCacheActions() {
+  return useStore((state) => ({
+    setProfile: state.setProfile,
+    getProfile: state.getProfile,
+    setFollowList: state.setFollowList,
+    getFollowList: state.getFollowList,
+    clearProfiles: state.clearProfiles,
+    clearAllCache: state.clearAllCache,
+  }))
+}
+
+// ====================================
+// Mute Helpers
+// ====================================
+
+/**
+ * Check if a pubkey is muted
+ */
+export function useIsMuted(pubkey: string): boolean {
+  return useStore((state) => state.mutedPubkeys.includes(pubkey))
+}
+
+/**
+ * Check if content contains muted words
+ */
+export function useContainsMutedWords(content: string): boolean {
+  return useStore((state) => {
+    const lowerContent = content.toLowerCase()
+    return state.mutedWords.some((word) =>
+      lowerContent.includes(word.toLowerCase())
+    )
+  })
+}

--- a/src/core/store/index.ts
+++ b/src/core/store/index.ts
@@ -1,0 +1,199 @@
+/**
+ * Zustand Store
+ *
+ * Central state management with cross-platform persistence
+ *
+ * @module core/store
+ */
+
+import { create } from 'zustand'
+import { persist, createJSONStorage, subscribeWithSelector } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+import type { Store, StoreState } from './types'
+import {
+  createAuthSlice,
+  createSettingsSlice,
+  createCacheSlice,
+  initialAuthState,
+  initialSettingsState,
+  initialCacheState,
+} from './slices'
+import {
+  STORE_NAME,
+  STORE_VERSION,
+  createPlatformStorage,
+  partializeState,
+  migrateStore,
+} from './persist'
+
+/**
+ * Storage adapter getter
+ * Lazily gets the storage adapter from platform container
+ */
+let storageAdapterGetter: (() => import('@/src/adapters/storage').StorageAdapter | null) | null = null
+
+/**
+ * Set the storage adapter getter
+ * Must be called before using the store with persistence
+ */
+export function setStorageAdapterGetter(
+  getter: () => import('@/src/adapters/storage').StorageAdapter | null
+): void {
+  storageAdapterGetter = getter
+}
+
+/**
+ * Initial state combining all slices
+ */
+const initialState: StoreState = {
+  ...initialAuthState,
+  ...initialSettingsState,
+  ...initialCacheState,
+}
+
+/**
+ * Create the Zustand store with all middleware
+ */
+export const useStore = create<Store>()(
+  subscribeWithSelector(
+    persist(
+      immer((...args) => ({
+        ...createAuthSlice(...args),
+        ...createSettingsSlice(...args),
+        ...createCacheSlice(...args),
+      })),
+      {
+        name: STORE_NAME,
+        version: STORE_VERSION,
+        storage: createJSONStorage(() =>
+          createPlatformStorage(() => storageAdapterGetter?.() ?? null)
+        ),
+        partialize: partializeState,
+        merge: (persistedState, currentState) => {
+          // Keep all actions from currentState, override with persisted values
+          const persisted = persistedState as Partial<StoreState> | undefined
+          return {
+            ...currentState,
+            // Auth state
+            pubkey: persisted?.pubkey ?? currentState.pubkey,
+            loginMethod: persisted?.loginMethod ?? currentState.loginMethod,
+            isLoggedIn: persisted?.pubkey ? true : currentState.isLoggedIn,
+            // Settings state
+            defaultZapAmount: persisted?.defaultZapAmount ?? currentState.defaultZapAmount,
+            lowBandwidthMode: persisted?.lowBandwidthMode ?? currentState.lowBandwidthMode,
+            autoSign: persisted?.autoSign ?? currentState.autoSign,
+            userGeohash: persisted?.userGeohash ?? currentState.userGeohash,
+            customRelays: persisted?.customRelays ?? currentState.customRelays,
+            mutedPubkeys: persisted?.mutedPubkeys ?? currentState.mutedPubkeys,
+            mutedWords: persisted?.mutedWords ?? currentState.mutedWords,
+          }
+        },
+        migrate: migrateStore,
+        skipHydration: true, // We'll hydrate manually after platform init
+      }
+    )
+  )
+)
+
+/**
+ * Hydrate the store from storage
+ * Call this after platform initialization
+ */
+export async function hydrateStore(): Promise<void> {
+  await useStore.persist.rehydrate()
+}
+
+/**
+ * Check if store has been hydrated
+ */
+export function isStoreHydrated(): boolean {
+  return useStore.persist.hasHydrated()
+}
+
+/**
+ * Subscribe to hydration completion
+ */
+export function onStoreHydrated(callback: () => void): () => void {
+  return useStore.persist.onFinishHydration(callback)
+}
+
+/**
+ * Clear all persisted store data
+ */
+export async function clearStore(): Promise<void> {
+  // Reset store to initial state
+  useStore.setState(initialState)
+  // Clear persisted data
+  const storage = storageAdapterGetter?.()
+  if (storage) {
+    await storage.removeItem(STORE_NAME)
+  }
+}
+
+/**
+ * Get current state snapshot (for non-React usage)
+ */
+export function getStoreState(): StoreState {
+  return useStore.getState()
+}
+
+/**
+ * Subscribe to state changes (for non-React usage)
+ */
+export function subscribeToStore(
+  listener: (state: Store, prevState: Store) => void
+): () => void {
+  return useStore.subscribe(listener)
+}
+
+/**
+ * Subscribe to specific state selector
+ */
+export function subscribeToSelector<T>(
+  selector: (state: Store) => T,
+  listener: (value: T, prevValue: T) => void,
+  options?: { equalityFn?: (a: T, b: T) => boolean; fireImmediately?: boolean }
+): () => void {
+  return useStore.subscribe(selector, listener, options)
+}
+
+// Re-export types
+export type { Store, StoreState } from './types'
+export type {
+  AuthState,
+  AuthActions,
+  SettingsState,
+  SettingsActions,
+  CacheState,
+  CacheActions,
+  Profile,
+  LoginMethod,
+} from './types'
+
+// Re-export constants
+export { PERSISTED_KEYS, CACHE_KEYS, MAX_CACHED_PROFILES, PROFILE_CACHE_TTL } from './types'
+export { STORE_NAME, STORE_VERSION } from './persist'
+
+// Re-export hooks
+export {
+  useAuth,
+  usePubkey,
+  useLoginMethod,
+  useIsLoggedIn,
+  useAuthActions,
+  useSettings,
+  useDefaultZapAmount,
+  useLowBandwidthMode,
+  useAutoSign,
+  useUserGeohash,
+  useCustomRelays,
+  useMutedPubkeys,
+  useMutedWords,
+  useSettingsActions,
+  useCachedProfile,
+  useFollowList,
+  useMyFollowList,
+  useCacheActions,
+  useIsMuted,
+  useContainsMutedWords,
+} from './hooks'

--- a/src/core/store/persist.ts
+++ b/src/core/store/persist.ts
@@ -1,0 +1,159 @@
+/**
+ * Store Persistence
+ *
+ * Custom persistence layer that integrates with the platform storage adapter
+ *
+ * @module core/store/persist
+ */
+
+import type { StateStorage } from 'zustand/middleware'
+import type { StorageAdapter } from '@/src/adapters/storage'
+import type { StoreState } from './types'
+import { PERSISTED_KEYS, CACHE_KEYS } from './types'
+
+/**
+ * Store name for the main persisted state
+ */
+export const STORE_NAME = 'nurunuru-store'
+
+/**
+ * Store name for the cache (separate storage)
+ */
+export const CACHE_STORE_NAME = 'nurunuru-cache'
+
+/**
+ * Create a Zustand-compatible storage that uses our StorageAdapter
+ *
+ * This bridges Zustand's persist middleware with our platform-agnostic storage
+ */
+export function createPlatformStorage(
+  getStorageAdapter: () => StorageAdapter | null
+): StateStorage {
+  return {
+    getItem: async (name: string): Promise<string | null> => {
+      const storage = getStorageAdapter()
+      if (!storage) {
+        console.warn('[Store] Storage adapter not available')
+        return null
+      }
+      try {
+        return await storage.getItem(name)
+      } catch (error) {
+        console.error('[Store] Failed to get item:', name, error)
+        return null
+      }
+    },
+
+    setItem: async (name: string, value: string): Promise<void> => {
+      const storage = getStorageAdapter()
+      if (!storage) {
+        console.warn('[Store] Storage adapter not available')
+        return
+      }
+      try {
+        await storage.setItem(name, value)
+      } catch (error) {
+        console.error('[Store] Failed to set item:', name, error)
+      }
+    },
+
+    removeItem: async (name: string): Promise<void> => {
+      const storage = getStorageAdapter()
+      if (!storage) {
+        console.warn('[Store] Storage adapter not available')
+        return
+      }
+      try {
+        await storage.removeItem(name)
+      } catch (error) {
+        console.error('[Store] Failed to remove item:', name, error)
+      }
+    },
+  }
+}
+
+/**
+ * Filter state to only include persisted keys
+ */
+export function partializeState(state: StoreState): Partial<StoreState> {
+  const persisted: Partial<StoreState> = {}
+
+  for (const key of PERSISTED_KEYS) {
+    if (key in state) {
+      ;(persisted as Record<string, unknown>)[key] = state[key]
+    }
+  }
+
+  return persisted
+}
+
+/**
+ * Filter state to only include cache keys
+ */
+export function partializeCacheState(state: StoreState): Partial<StoreState> {
+  const cache: Partial<StoreState> = {}
+
+  for (const key of CACHE_KEYS) {
+    if (key in state) {
+      ;(cache as Record<string, unknown>)[key] = state[key]
+    }
+  }
+
+  return cache
+}
+
+/**
+ * Merge persisted state with current state
+ * Handles migration and default values
+ */
+export function mergeState(
+  currentState: StoreState,
+  persistedState: Partial<StoreState> | undefined
+): StoreState {
+  if (!persistedState) {
+    return currentState
+  }
+
+  // Deep merge with type safety
+  return {
+    ...currentState,
+    // Auth state
+    pubkey: persistedState.pubkey ?? currentState.pubkey,
+    loginMethod: persistedState.loginMethod ?? currentState.loginMethod,
+    isLoggedIn: persistedState.pubkey ? true : currentState.isLoggedIn,
+    // Settings state
+    defaultZapAmount:
+      persistedState.defaultZapAmount ?? currentState.defaultZapAmount,
+    lowBandwidthMode:
+      persistedState.lowBandwidthMode ?? currentState.lowBandwidthMode,
+    autoSign: persistedState.autoSign ?? currentState.autoSign,
+    userGeohash: persistedState.userGeohash ?? currentState.userGeohash,
+    customRelays: persistedState.customRelays ?? currentState.customRelays,
+    mutedPubkeys: persistedState.mutedPubkeys ?? currentState.mutedPubkeys,
+    mutedWords: persistedState.mutedWords ?? currentState.mutedWords,
+    // Cache state (kept from current)
+    profiles: currentState.profiles,
+    followLists: currentState.followLists,
+  }
+}
+
+/**
+ * Version number for state migration
+ */
+export const STORE_VERSION = 1
+
+/**
+ * Migration function for store version updates
+ */
+export function migrateStore(
+  persistedState: unknown,
+  version: number
+): Partial<StoreState> {
+  // Version 0 -> 1: Initial version, no migration needed
+  if (version === 0) {
+    // Future migrations can be added here
+    return persistedState as Partial<StoreState>
+  }
+
+  return persistedState as Partial<StoreState>
+}

--- a/src/core/store/slices/auth.ts
+++ b/src/core/store/slices/auth.ts
@@ -1,0 +1,53 @@
+/**
+ * Auth Slice
+ *
+ * Manages authentication state including login/logout
+ *
+ * @module core/store/slices/auth
+ */
+
+import type { StateCreator } from 'zustand'
+import type { Store, AuthState, AuthActions, LoginMethod } from '../types'
+
+/**
+ * Initial auth state
+ */
+export const initialAuthState: AuthState = {
+  pubkey: null,
+  loginMethod: null,
+  isLoggedIn: false,
+}
+
+/**
+ * Create auth slice
+ */
+export const createAuthSlice: StateCreator<
+  Store,
+  [['zustand/immer', never]],
+  [],
+  AuthState & AuthActions
+> = (set) => ({
+  ...initialAuthState,
+
+  login: (pubkey: string, method: LoginMethod) => {
+    set((state) => {
+      state.pubkey = pubkey
+      state.loginMethod = method
+      state.isLoggedIn = true
+    })
+  },
+
+  logout: () => {
+    set((state) => {
+      state.pubkey = null
+      state.loginMethod = null
+      state.isLoggedIn = false
+    })
+  },
+
+  setPubkey: (pubkey: string) => {
+    set((state) => {
+      state.pubkey = pubkey
+    })
+  },
+})

--- a/src/core/store/slices/cache.ts
+++ b/src/core/store/slices/cache.ts
@@ -1,0 +1,120 @@
+/**
+ * Cache Slice
+ *
+ * Manages profile and follow list caching with LRU-like behavior
+ *
+ * @module core/store/slices/cache
+ */
+
+import type { StateCreator } from 'zustand'
+import type {
+  Store,
+  CacheState,
+  CacheActions,
+  Profile,
+} from '../types'
+import { MAX_CACHED_PROFILES, PROFILE_CACHE_TTL } from '../types'
+
+/**
+ * Initial cache state
+ */
+export const initialCacheState: CacheState = {
+  profiles: {},
+  followLists: {},
+}
+
+/**
+ * Evict oldest profiles if cache exceeds limit
+ */
+function evictOldestProfiles(
+  profiles: Record<string, Profile>,
+  maxSize: number
+): Record<string, Profile> {
+  const entries = Object.entries(profiles)
+  if (entries.length <= maxSize) {
+    return profiles
+  }
+
+  // Sort by fetchedAt (oldest first)
+  entries.sort((a, b) => a[1].fetchedAt - b[1].fetchedAt)
+
+  // Keep only the newest entries
+  const toKeep = entries.slice(entries.length - maxSize)
+  const result: Record<string, Profile> = {}
+  for (const [key, value] of toKeep) {
+    result[key] = value
+  }
+  return result
+}
+
+/**
+ * Check if a profile is stale (older than TTL)
+ */
+function isProfileStale(profile: Profile): boolean {
+  return Date.now() - profile.fetchedAt > PROFILE_CACHE_TTL
+}
+
+/**
+ * Create cache slice
+ */
+export const createCacheSlice: StateCreator<
+  Store,
+  [['zustand/immer', never]],
+  [],
+  CacheState & CacheActions
+> = (set, get) => ({
+  ...initialCacheState,
+
+  setProfile: (profile: Profile) => {
+    set((state) => {
+      // Add or update profile
+      state.profiles[profile.pubkey] = {
+        ...profile,
+        fetchedAt: profile.fetchedAt || Date.now(),
+      }
+
+      // Evict old profiles if over limit
+      if (Object.keys(state.profiles).length > MAX_CACHED_PROFILES) {
+        state.profiles = evictOldestProfiles(
+          state.profiles,
+          MAX_CACHED_PROFILES
+        )
+      }
+    })
+  },
+
+  getProfile: (pubkey: string) => {
+    const profile = get().profiles[pubkey]
+    if (!profile) return undefined
+
+    // Check if stale
+    if (isProfileStale(profile)) {
+      return undefined
+    }
+
+    return profile
+  },
+
+  setFollowList: (pubkey: string, follows: string[]) => {
+    set((state) => {
+      state.followLists[pubkey] = follows
+    })
+  },
+
+  getFollowList: (pubkey: string) => {
+    return get().followLists[pubkey]
+  },
+
+  clearProfiles: () => {
+    set((state) => {
+      state.profiles = {}
+    })
+  },
+
+  clearAllCache: () => {
+    set((state) => {
+      state.profiles = {}
+      state.followLists = {}
+    })
+  },
+})

--- a/src/core/store/slices/index.ts
+++ b/src/core/store/slices/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Store Slices
+ *
+ * Re-exports all store slices
+ *
+ * @module core/store/slices
+ */
+
+export { createAuthSlice, initialAuthState } from './auth'
+export { createSettingsSlice, initialSettingsState } from './settings'
+export { createCacheSlice, initialCacheState } from './cache'

--- a/src/core/store/slices/settings.ts
+++ b/src/core/store/slices/settings.ts
@@ -1,0 +1,116 @@
+/**
+ * Settings Slice
+ *
+ * Manages user preferences and settings
+ *
+ * @module core/store/slices/settings
+ */
+
+import type { StateCreator } from 'zustand'
+import type { Store, SettingsState, SettingsActions } from '../types'
+
+/**
+ * Initial settings state with defaults
+ */
+export const initialSettingsState: SettingsState = {
+  defaultZapAmount: 1000,
+  lowBandwidthMode: false,
+  autoSign: false,
+  userGeohash: null,
+  customRelays: [],
+  mutedPubkeys: [],
+  mutedWords: [],
+}
+
+/**
+ * Create settings slice
+ */
+export const createSettingsSlice: StateCreator<
+  Store,
+  [['zustand/immer', never]],
+  [],
+  SettingsState & SettingsActions
+> = (set) => ({
+  ...initialSettingsState,
+
+  setDefaultZapAmount: (amount: number) => {
+    set((state) => {
+      state.defaultZapAmount = amount
+    })
+  },
+
+  setLowBandwidthMode: (enabled: boolean) => {
+    set((state) => {
+      state.lowBandwidthMode = enabled
+    })
+  },
+
+  setAutoSign: (enabled: boolean) => {
+    set((state) => {
+      state.autoSign = enabled
+    })
+  },
+
+  setUserGeohash: (geohash: string | null) => {
+    set((state) => {
+      state.userGeohash = geohash
+    })
+  },
+
+  addCustomRelay: (url: string) => {
+    set((state) => {
+      if (!state.customRelays.includes(url)) {
+        state.customRelays.push(url)
+      }
+    })
+  },
+
+  removeCustomRelay: (url: string) => {
+    set((state) => {
+      const index = state.customRelays.indexOf(url)
+      if (index !== -1) {
+        state.customRelays.splice(index, 1)
+      }
+    })
+  },
+
+  setCustomRelays: (urls: string[]) => {
+    set((state) => {
+      state.customRelays = urls
+    })
+  },
+
+  addMutedPubkey: (pubkey: string) => {
+    set((state) => {
+      if (!state.mutedPubkeys.includes(pubkey)) {
+        state.mutedPubkeys.push(pubkey)
+      }
+    })
+  },
+
+  removeMutedPubkey: (pubkey: string) => {
+    set((state) => {
+      const index = state.mutedPubkeys.indexOf(pubkey)
+      if (index !== -1) {
+        state.mutedPubkeys.splice(index, 1)
+      }
+    })
+  },
+
+  addMutedWord: (word: string) => {
+    set((state) => {
+      if (!state.mutedWords.includes(word)) {
+        state.mutedWords.push(word)
+      }
+    })
+  },
+
+  removeMutedWord: (word: string) => {
+    set((state) => {
+      const index = state.mutedWords.indexOf(word)
+      if (index !== -1) {
+        state.mutedWords.splice(index, 1)
+      }
+    })
+  },
+})

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Store Types
+ *
+ * Type definitions for the Zustand store
+ *
+ * @module core/store/types
+ */
+
+import type { SignerType } from '@/src/adapters/signing'
+
+/**
+ * Login methods supported by the app
+ */
+export type LoginMethod =
+  | 'nip07'
+  | 'nosskey'
+  | 'amber'
+  | 'bunker'
+  | 'nsec'
+  | 'nsec-app'
+
+/**
+ * Authentication state
+ */
+export interface AuthState {
+  /** Current user's public key (hex) */
+  pubkey: string | null
+  /** Method used to login */
+  loginMethod: LoginMethod | null
+  /** Whether the user is logged in */
+  isLoggedIn: boolean
+}
+
+/**
+ * Authentication actions
+ */
+export interface AuthActions {
+  /** Log in with a public key and method */
+  login: (pubkey: string, method: LoginMethod) => void
+  /** Log out and clear auth state */
+  logout: () => void
+  /** Set just the pubkey (for Amber signer that needs pubkey before signing) */
+  setPubkey: (pubkey: string) => void
+}
+
+/**
+ * Settings state
+ */
+export interface SettingsState {
+  /** Default amount for Zap (in sats) */
+  defaultZapAmount: number
+  /** Enable low bandwidth mode */
+  lowBandwidthMode: boolean
+  /** Auto-sign events without confirmation */
+  autoSign: boolean
+  /** User's geohash for location-based features */
+  userGeohash: string | null
+  /** Custom relay list */
+  customRelays: string[]
+  /** Muted public keys */
+  mutedPubkeys: string[]
+  /** Muted words for content filtering */
+  mutedWords: string[]
+}
+
+/**
+ * Settings actions
+ */
+export interface SettingsActions {
+  setDefaultZapAmount: (amount: number) => void
+  setLowBandwidthMode: (enabled: boolean) => void
+  setAutoSign: (enabled: boolean) => void
+  setUserGeohash: (geohash: string | null) => void
+  addCustomRelay: (url: string) => void
+  removeCustomRelay: (url: string) => void
+  setCustomRelays: (urls: string[]) => void
+  addMutedPubkey: (pubkey: string) => void
+  removeMutedPubkey: (pubkey: string) => void
+  addMutedWord: (word: string) => void
+  removeMutedWord: (word: string) => void
+}
+
+/**
+ * Profile data structure
+ */
+export interface Profile {
+  pubkey: string
+  name?: string
+  displayName?: string
+  picture?: string
+  banner?: string
+  about?: string
+  nip05?: string
+  lud16?: string
+  website?: string
+  /** Timestamp when this profile was fetched */
+  fetchedAt: number
+}
+
+/**
+ * Profile cache state
+ */
+export interface CacheState {
+  /** Profile cache (LRU-like, limited entries) */
+  profiles: Record<string, Profile>
+  /** Follow lists by pubkey */
+  followLists: Record<string, string[]>
+}
+
+/**
+ * Cache actions
+ */
+export interface CacheActions {
+  /** Set a profile in cache */
+  setProfile: (profile: Profile) => void
+  /** Get a profile from cache */
+  getProfile: (pubkey: string) => Profile | undefined
+  /** Set follow list for a pubkey */
+  setFollowList: (pubkey: string, follows: string[]) => void
+  /** Get follow list for a pubkey */
+  getFollowList: (pubkey: string) => string[] | undefined
+  /** Clear all cached profiles */
+  clearProfiles: () => void
+  /** Clear all cache */
+  clearAllCache: () => void
+}
+
+/**
+ * Combined store state
+ */
+export type StoreState = AuthState & SettingsState & CacheState
+
+/**
+ * Combined store actions
+ */
+export type StoreActions = AuthActions & SettingsActions & CacheActions
+
+/**
+ * Complete store type
+ */
+export type Store = StoreState & StoreActions
+
+/**
+ * Keys that should be persisted to storage
+ */
+export const PERSISTED_KEYS: (keyof StoreState)[] = [
+  'pubkey',
+  'loginMethod',
+  'defaultZapAmount',
+  'lowBandwidthMode',
+  'autoSign',
+  'userGeohash',
+  'customRelays',
+  'mutedPubkeys',
+  'mutedWords',
+]
+
+/**
+ * Keys for profile cache (separate storage)
+ */
+export const CACHE_KEYS: (keyof CacheState)[] = ['profiles', 'followLists']
+
+/**
+ * Maximum number of profiles to keep in cache
+ */
+export const MAX_CACHED_PROFILES = 500
+
+/**
+ * Profile cache TTL in milliseconds (24 hours)
+ */
+export const PROFILE_CACHE_TTL = 24 * 60 * 60 * 1000

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,9 @@ export * from './platform'
 // Adapters
 export * from './adapters/storage'
 export * from './adapters/signing'
+
+// State management
+export * from './core/store'
+
+// Compatibility layer
+export * from './lib/compat'

--- a/src/lib/compat/index.ts
+++ b/src/lib/compat/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Compatibility Layer
+ *
+ * Provides backwards-compatible APIs for gradual migration
+ * from localStorage to the new platform-agnostic storage system.
+ *
+ * @module lib/compat
+ */
+
+// Storage compatibility
+export { storage, migrateFromLocalStorage, LEGACY_KEYS } from './storage'
+export type { CompatStorage } from './storage'
+
+// Store compatibility
+export {
+  initializeStore,
+  syncToLegacyStorage,
+  getUserPubkey,
+  getLoginMethod,
+  isLoggedIn,
+  login,
+  logout,
+  getDefaultZapAmount,
+  setDefaultZapAmount,
+  getCachedProfile,
+  setCachedProfile,
+} from './store'

--- a/src/lib/compat/storage.ts
+++ b/src/lib/compat/storage.ts
@@ -1,0 +1,213 @@
+/**
+ * Storage Compatibility Layer
+ *
+ * Provides a synchronous-like API that bridges old localStorage code
+ * with the new async StorageAdapter system.
+ *
+ * Usage (gradual migration):
+ * Before: localStorage.getItem('key')
+ * After:  await storage.getItem('key')
+ *
+ * @module lib/compat/storage
+ */
+
+import { getStorage as getPlatformStorage, isInitialized } from '@/src/platform'
+import type { StorageAdapter } from '@/src/adapters/storage'
+
+/**
+ * Legacy storage interface that matches localStorage API but is async
+ */
+export interface CompatStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+  clear(): Promise<void>
+  keys(): Promise<string[]>
+
+  // JSON helpers
+  getJSON<T>(key: string): Promise<T | null>
+  setJSON<T>(key: string, value: T): Promise<void>
+}
+
+/**
+ * In-memory fallback for SSR
+ */
+const memoryFallback = new Map<string, string>()
+
+/**
+ * Get the storage adapter, with fallback for non-initialized state
+ */
+function getStorageAdapter(): StorageAdapter | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  if (!isInitialized()) {
+    console.warn(
+      '[CompatStorage] Platform not initialized, using localStorage directly'
+    )
+    return null
+  }
+
+  return getPlatformStorage()
+}
+
+/**
+ * Fallback to localStorage when adapter not available
+ */
+function localStorageFallback() {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage
+  }
+  return null
+}
+
+/**
+ * Compatible storage instance
+ */
+export const storage: CompatStorage = {
+  async getItem(key: string): Promise<string | null> {
+    const adapter = getStorageAdapter()
+    if (adapter) {
+      return adapter.getItem(key)
+    }
+
+    // Fallback
+    const ls = localStorageFallback()
+    if (ls) {
+      return ls.getItem(key)
+    }
+
+    return memoryFallback.get(key) ?? null
+  },
+
+  async setItem(key: string, value: string): Promise<void> {
+    const adapter = getStorageAdapter()
+    if (adapter) {
+      return adapter.setItem(key, value)
+    }
+
+    // Fallback
+    const ls = localStorageFallback()
+    if (ls) {
+      ls.setItem(key, value)
+      return
+    }
+
+    memoryFallback.set(key, value)
+  },
+
+  async removeItem(key: string): Promise<void> {
+    const adapter = getStorageAdapter()
+    if (adapter) {
+      return adapter.removeItem(key)
+    }
+
+    // Fallback
+    const ls = localStorageFallback()
+    if (ls) {
+      ls.removeItem(key)
+      return
+    }
+
+    memoryFallback.delete(key)
+  },
+
+  async clear(): Promise<void> {
+    const adapter = getStorageAdapter()
+    if (adapter) {
+      return adapter.clear()
+    }
+
+    // Fallback
+    const ls = localStorageFallback()
+    if (ls) {
+      ls.clear()
+      return
+    }
+
+    memoryFallback.clear()
+  },
+
+  async keys(): Promise<string[]> {
+    const adapter = getStorageAdapter()
+    if (adapter) {
+      return adapter.keys()
+    }
+
+    // Fallback
+    const ls = localStorageFallback()
+    if (ls) {
+      return Object.keys(ls)
+    }
+
+    return Array.from(memoryFallback.keys())
+  },
+
+  async getJSON<T>(key: string): Promise<T | null> {
+    const value = await this.getItem(key)
+    if (value === null) return null
+    try {
+      return JSON.parse(value) as T
+    } catch {
+      console.warn(`[CompatStorage] Failed to parse JSON for key: ${key}`)
+      return null
+    }
+  },
+
+  async setJSON<T>(key: string, value: T): Promise<void> {
+    await this.setItem(key, JSON.stringify(value))
+  },
+}
+
+/**
+ * Migration helper: Copy old localStorage keys to new storage
+ */
+export async function migrateFromLocalStorage(
+  keys: string[]
+): Promise<{ migrated: string[]; failed: string[] }> {
+  const migrated: string[] = []
+  const failed: string[] = []
+
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return { migrated, failed }
+  }
+
+  const adapter = getStorageAdapter()
+  if (!adapter) {
+    return { migrated, failed }
+  }
+
+  for (const key of keys) {
+    try {
+      const value = window.localStorage.getItem(key)
+      if (value !== null) {
+        await adapter.setItem(key, value)
+        migrated.push(key)
+      }
+    } catch (error) {
+      console.error(`[Migration] Failed to migrate key: ${key}`, error)
+      failed.push(key)
+    }
+  }
+
+  return { migrated, failed }
+}
+
+/**
+ * Legacy key mappings for backwards compatibility
+ */
+export const LEGACY_KEYS = {
+  // Auth
+  USER_PUBKEY: 'user_pubkey',
+  LOGIN_METHOD: 'nurunuru_login_method',
+
+  // Settings
+  DEFAULT_ZAP_AMOUNT: 'defaultZapAmount',
+  AUTO_SIGN: 'nurunuru_auto_sign',
+  USER_GEOHASH: 'user_geohash',
+
+  // Signer-specific
+  NOSSKEY: 'nurunuru_nosskey',
+  BUNKER_SESSION: 'nurunuru_bunker_session',
+} as const

--- a/src/lib/compat/store.ts
+++ b/src/lib/compat/store.ts
@@ -1,0 +1,199 @@
+/**
+ * Store Compatibility Layer
+ *
+ * Bridges the new Zustand store with legacy localStorage-based code.
+ * This allows gradual migration without breaking existing functionality.
+ *
+ * @module lib/compat/store
+ */
+
+import {
+  useStore,
+  hydrateStore,
+  setStorageAdapterGetter,
+  getStoreState,
+} from '@/src/core/store'
+import type { LoginMethod, Profile } from '@/src/core/store'
+import { storage, LEGACY_KEYS } from './storage'
+import { getStorage, isInitialized } from '@/src/platform'
+
+/**
+ * Initialize the store with platform storage
+ * Should be called after platform initialization
+ */
+export async function initializeStore(): Promise<void> {
+  // Set up storage adapter getter for the store
+  setStorageAdapterGetter(() => {
+    if (!isInitialized()) return null
+    return getStorage()
+  })
+
+  // Hydrate from storage
+  await hydrateStore()
+
+  // Migrate from legacy localStorage if needed
+  await migrateFromLegacyStorage()
+}
+
+/**
+ * Migrate data from legacy localStorage keys to Zustand store
+ */
+async function migrateFromLegacyStorage(): Promise<void> {
+  const state = getStoreState()
+
+  // Only migrate if store is empty (first run after migration)
+  if (state.pubkey) {
+    return
+  }
+
+  // Try to get legacy values
+  const legacyPubkey = await storage.getItem(LEGACY_KEYS.USER_PUBKEY)
+  const legacyMethod = await storage.getItem(LEGACY_KEYS.LOGIN_METHOD) as LoginMethod | null
+  const legacyZapAmount = await storage.getItem(LEGACY_KEYS.DEFAULT_ZAP_AMOUNT)
+  const legacyAutoSign = await storage.getItem(LEGACY_KEYS.AUTO_SIGN)
+  const legacyGeohash = await storage.getItem(LEGACY_KEYS.USER_GEOHASH)
+
+  if (legacyPubkey && legacyMethod) {
+    console.log('[Migration] Migrating auth state from localStorage')
+    useStore.getState().login(legacyPubkey, legacyMethod)
+  }
+
+  if (legacyZapAmount) {
+    const amount = parseInt(legacyZapAmount, 10)
+    if (!isNaN(amount)) {
+      useStore.getState().setDefaultZapAmount(amount)
+    }
+  }
+
+  if (legacyAutoSign === 'true') {
+    useStore.getState().setAutoSign(true)
+  }
+
+  if (legacyGeohash) {
+    useStore.getState().setUserGeohash(legacyGeohash)
+  }
+}
+
+/**
+ * Sync store changes back to legacy localStorage
+ * This maintains backwards compatibility during migration period
+ */
+export function syncToLegacyStorage(): () => void {
+  return useStore.subscribe(
+    (state) => ({
+      pubkey: state.pubkey,
+      loginMethod: state.loginMethod,
+      defaultZapAmount: state.defaultZapAmount,
+      autoSign: state.autoSign,
+      userGeohash: state.userGeohash,
+    }),
+    async (current, prev) => {
+      // Sync auth changes
+      if (current.pubkey !== prev.pubkey) {
+        if (current.pubkey) {
+          await storage.setItem(LEGACY_KEYS.USER_PUBKEY, current.pubkey)
+        } else {
+          await storage.removeItem(LEGACY_KEYS.USER_PUBKEY)
+        }
+      }
+
+      if (current.loginMethod !== prev.loginMethod) {
+        if (current.loginMethod) {
+          await storage.setItem(LEGACY_KEYS.LOGIN_METHOD, current.loginMethod)
+        } else {
+          await storage.removeItem(LEGACY_KEYS.LOGIN_METHOD)
+        }
+      }
+
+      // Sync settings changes
+      if (current.defaultZapAmount !== prev.defaultZapAmount) {
+        await storage.setItem(
+          LEGACY_KEYS.DEFAULT_ZAP_AMOUNT,
+          String(current.defaultZapAmount)
+        )
+      }
+
+      if (current.autoSign !== prev.autoSign) {
+        await storage.setItem(
+          LEGACY_KEYS.AUTO_SIGN,
+          current.autoSign ? 'true' : 'false'
+        )
+      }
+
+      if (current.userGeohash !== prev.userGeohash) {
+        if (current.userGeohash) {
+          await storage.setItem(LEGACY_KEYS.USER_GEOHASH, current.userGeohash)
+        } else {
+          await storage.removeItem(LEGACY_KEYS.USER_GEOHASH)
+        }
+      }
+    }
+  )
+}
+
+// ====================================
+// Legacy API Wrappers
+// ====================================
+
+/**
+ * Get current user's pubkey (legacy API)
+ */
+export function getUserPubkey(): string | null {
+  return getStoreState().pubkey
+}
+
+/**
+ * Get login method (legacy API)
+ */
+export function getLoginMethod(): LoginMethod | null {
+  return getStoreState().loginMethod
+}
+
+/**
+ * Check if user is logged in (legacy API)
+ */
+export function isLoggedIn(): boolean {
+  return getStoreState().isLoggedIn
+}
+
+/**
+ * Login (legacy API)
+ */
+export function login(pubkey: string, method: LoginMethod): void {
+  useStore.getState().login(pubkey, method)
+}
+
+/**
+ * Logout (legacy API)
+ */
+export function logout(): void {
+  useStore.getState().logout()
+}
+
+/**
+ * Get default zap amount (legacy API)
+ */
+export function getDefaultZapAmount(): number {
+  return getStoreState().defaultZapAmount
+}
+
+/**
+ * Set default zap amount (legacy API)
+ */
+export function setDefaultZapAmount(amount: number): void {
+  useStore.getState().setDefaultZapAmount(amount)
+}
+
+/**
+ * Get cached profile (legacy API)
+ */
+export function getCachedProfile(pubkey: string): Profile | undefined {
+  return useStore.getState().getProfile(pubkey)
+}
+
+/**
+ * Set cached profile (legacy API)
+ */
+export function setCachedProfile(profile: Profile): void {
+  useStore.getState().setProfile(profile)
+}


### PR DESCRIPTION
- zustand と immer パッケージを追加
- src/core/store/ に Zustand ストアを実装:
  - Auth slice: 認証状態管理 (pubkey, loginMethod, isLoggedIn)
  - Settings slice: 設定管理 (zapAmount, autoSign, relays, mutes)
  - Cache slice: プロフィール/フォローリストキャッシュ (LRU)
- クロスプラットフォーム永続化:
  - Platform Storage Adapter との統合
  - persist middleware による自動永続化
  - skipHydration で手動ハイドレーション制御
- React Hooks を追加:
  - useAuth, usePubkey, useIsLoggedIn
  - useSettings, useDefaultZapAmount, useAutoSign
  - useCachedProfile, useFollowList, useMutedPubkeys
- 互換レイヤー (src/lib/compat/):
  - storage.ts: localStorage から新 Storage Adapter への移行支援
  - store.ts: 既存コードとの後方互換性を維持
  - 旧 localStorage キーからの自動マイグレーション

https://claude.ai/code/session_014Xy2yY9r2pXvDzic64NYSD