### PR TITLE
feat: Phase 3 コンポーネント分割完了 + React Native 移行プラン追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,6 +826,382 @@ const pubkey = useStore((state) => state.pubkey)
 
 ---
 
+## 実装完了状況
+
+> **更新日**: 2026-01-30
+
+### Phase 完了状況
+
+| Phase | 内容 | 状況 | 実装ファイル数 |
+|-------|------|------|---------------|
+| **Phase 1** | 抽象化レイヤーの構築 | ✅ **完了** | 25+ ファイル |
+| **Phase 2** | 状態管理の統一 | ✅ **完了** | 8 ファイル |
+| **Phase 3** | コンポーネントの分割 | ✅ **完了** | 15+ ファイル |
+| **Phase 4** | プラットフォーム固有実装 | ✅ **完了** | 3 ファイル |
+| **Phase 5** | テスト戦略 | ✅ **完了** | 6 ファイル |
+
+### 新規実装されたアーキテクチャ
+
+```
+src/
+├── adapters/                      # ✅ 完了
+│   ├── storage/                   # WebStorage, CapacitorStorage, ElectronStorage, MemoryStorage
+│   ├── signing/                   # Nip07Signer, NosskeySigner, AmberSigner, MemorySigner
+│   ├── clipboard/                 # WebClipboard, CapacitorClipboard, ElectronClipboard
+│   └── network/                   # WebNetwork, CapacitorNetwork, ElectronNetwork
+│
+├── core/                          # ✅ 完了
+│   └── store/                     # Zustand Store with slices (auth, settings, cache)
+│
+├── platform/                      # ✅ 完了
+│   ├── detect.ts                  # Platform detection utilities
+│   ├── container.ts               # DI Container
+│   ├── web.ts                     # Web platform initialization
+│   ├── capacitor.ts               # Capacitor platform initialization
+│   └── electron.ts                # Electron platform initialization
+│
+├── ui/                            # ✅ 完了
+│   ├── components/
+│   │   ├── common/                # LoadingState, ErrorState, ZapModal, ContentPreview
+│   │   ├── timeline/              # TimelineHeader, TimelineList, TimelineLoading, TimelineEmpty
+│   │   ├── settings/              # NosskeySettings, RelaySection, MuteSection, UploadSection, etc.
+│   │   └── post/                  # PostModal
+│   └── hooks/                     # useTimeline, useSettings
+│
+├── lib/
+│   └── compat/                    # ✅ 完了 - 互換レイヤー (storage.ts)
+│
+└── __tests__/                     # ✅ 完了
+    ├── adapters/                  # Storage, Signing adapter tests
+    ├── platform/                  # Platform detection tests
+    ├── store/                     # Store and hooks tests
+    └── integration/               # Store-adapter integration tests
+```
+
+---
+
+## Phase 6: React Native 移行プラン
+
+> **ステータス**: 計画段階
+> **優先度**: 将来の拡張
+
+### 概要
+
+現在のアーキテクチャ基盤（Phase 1-5）が完成したことで、React Native への移行が可能になりました。
+以下のプランに沿って、真のネイティブアプリ開発を進めます。
+
+### React Native 移行のメリット
+
+| 項目 | Capacitor (WebView) | React Native |
+|------|---------------------|--------------|
+| **パフォーマンス** | Web ベース | ネイティブ UI |
+| **アニメーション** | CSS/JS 制限あり | 60fps ネイティブ |
+| **メモリ使用量** | WebView オーバーヘッド | 最適化済み |
+| **OS 統合** | プラグイン経由 | 直接アクセス |
+| **アプリサイズ** | 中程度 | 小さい |
+
+### 再利用可能なコード（約80%）
+
+現在のアーキテクチャで以下のコードが React Native でそのまま使用可能：
+
+```
+✅ 再利用可能 (src/core/)
+├── store/                         # Zustand Store - 100% 再利用
+│   ├── slices/auth.ts
+│   ├── slices/settings.ts
+│   └── slices/cache.ts
+│
+├── adapters/                      # Interface 定義 - 100% 再利用
+│   ├── storage/StorageAdapter.ts
+│   ├── signing/SigningAdapter.ts
+│   └── ...
+│
+└── lib/                           # ビジネスロジック - 95% 再利用
+    ├── nostr.js                   # Nostr プロトコル
+    └── compat/storage.ts          # 互換レイヤー
+
+⚠️ 要修正 (src/ui/)
+├── components/                    # React Native 用に書き換え
+│   ├── Web: <div>, <button>
+│   └── RN:  <View>, <TouchableOpacity>
+│
+└── hooks/                         # ほぼそのまま使用可能
+    ├── useTimeline.ts             # ✅ ロジックは再利用
+    └── useSettings.ts             # ✅ ロジックは再利用
+
+❌ 新規実装 (react-native/)
+├── adapters/
+│   ├── RNStorage.ts               # AsyncStorage
+│   └── RNSigner.ts                # Amber Intent / NIP-55
+│
+├── platform/
+│   └── react-native.ts            # RN platform initialization
+│
+└── navigation/                    # React Navigation
+```
+
+### React Native プロジェクト構造
+
+```
+nurunuru-rn/
+├── src/
+│   ├── core/                      # ← 既存コードをコピー
+│   │   ├── store/
+│   │   └── adapters/interfaces/
+│   │
+│   ├── adapters/                  # React Native 固有実装
+│   │   ├── storage/
+│   │   │   └── RNAsyncStorage.ts
+│   │   ├── signing/
+│   │   │   ├── RNAmberSigner.ts   # Android
+│   │   │   └── RNNostrichSigner.ts # iOS (将来)
+│   │   ├── clipboard/
+│   │   │   └── RNClipboard.ts
+│   │   └── network/
+│   │       └── RNNetwork.ts
+│   │
+│   ├── platform/
+│   │   └── react-native.ts
+│   │
+│   ├── screens/                   # React Native スクリーン
+│   │   ├── Timeline/
+│   │   │   ├── TimelineScreen.tsx
+│   │   │   └── components/
+│   │   ├── Profile/
+│   │   ├── Settings/
+│   │   └── Login/
+│   │
+│   ├── components/                # 共通コンポーネント
+│   │   ├── PostItem.tsx
+│   │   ├── Avatar.tsx
+│   │   └── ...
+│   │
+│   ├── navigation/
+│   │   ├── AppNavigator.tsx
+│   │   └── TabNavigator.tsx
+│   │
+│   └── hooks/                     # ← 既存フックを移植
+│       ├── useTimeline.ts
+│       └── useSettings.ts
+│
+├── android/
+├── ios/
+├── package.json
+└── metro.config.js
+```
+
+### React Native Adapter 実装例
+
+```typescript
+// src/adapters/storage/RNAsyncStorage.ts
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type { StorageAdapter } from '@/core/adapters/storage/StorageAdapter'
+
+export class RNAsyncStorage implements StorageAdapter {
+  async getItem(key: string): Promise<string | null> {
+    return AsyncStorage.getItem(key)
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    await AsyncStorage.setItem(key, value)
+  }
+
+  async removeItem(key: string): Promise<void> {
+    await AsyncStorage.removeItem(key)
+  }
+
+  async clear(): Promise<void> {
+    await AsyncStorage.clear()
+  }
+
+  async keys(): Promise<string[]> {
+    return AsyncStorage.getAllKeys()
+  }
+}
+
+// src/adapters/signing/RNAmberSigner.ts
+import { Linking } from 'react-native'
+import type { SigningAdapter, SignerType, SignerFeature } from '@/core/adapters/signing/SigningAdapter'
+
+export class RNAmberSigner implements SigningAdapter {
+  readonly type: SignerType = 'amber'
+
+  async getPublicKey(): Promise<string> {
+    // Amber deep link を使用
+    const result = await Linking.openURL('nostrsigner:')
+    // ... intent response 処理
+  }
+
+  async signEvent(event: UnsignedEvent): Promise<Event> {
+    const eventJson = JSON.stringify(event)
+    const intentUrl = `nostrsigner:${eventJson}?type=sign_event`
+    // ... intent response 処理
+  }
+
+  supports(feature: SignerFeature): boolean {
+    return ['nip04', 'nip44'].includes(feature)
+  }
+}
+
+// src/platform/react-native.ts
+import { Platform } from 'react-native'
+import { RNAsyncStorage } from '@/adapters/storage/RNAsyncStorage'
+import { RNAmberSigner } from '@/adapters/signing/RNAmberSigner'
+import { RNClipboard } from '@/adapters/clipboard/RNClipboard'
+import { RNNetwork } from '@/adapters/network/RNNetwork'
+
+export function initializeReactNative(): AdapterContainer {
+  return {
+    storage: new RNAsyncStorage(),
+    signer: Platform.OS === 'android' ? new RNAmberSigner() : null,
+    clipboard: new RNClipboard(),
+    network: new RNNetwork(),
+  }
+}
+```
+
+### React Native UI コンポーネント例
+
+```tsx
+// screens/Timeline/TimelineScreen.tsx
+import React from 'react'
+import { View, FlatList, RefreshControl } from 'react-native'
+import { useTimeline } from '@/hooks/useTimeline'
+import { TimelineHeader } from './components/TimelineHeader'
+import { PostItem } from '@/components/PostItem'
+import { TimelineEmpty } from './components/TimelineEmpty'
+import { TimelineLoading } from './components/TimelineLoading'
+
+export function TimelineScreen() {
+  const {
+    posts,
+    isLoading,
+    isRefreshing,
+    fetchMore,
+    refresh,
+  } = useTimeline()
+
+  return (
+    <View style={{ flex: 1 }}>
+      <TimelineHeader />
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <PostItem post={item} />}
+        ListEmptyComponent={isLoading ? <TimelineLoading /> : <TimelineEmpty />}
+        refreshControl={
+          <RefreshControl refreshing={isRefreshing} onRefresh={refresh} />
+        }
+        onEndReached={fetchMore}
+        onEndReachedThreshold={0.5}
+      />
+    </View>
+  )
+}
+
+// components/PostItem.tsx
+import React from 'react'
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { Avatar } from './Avatar'
+import { PostContent } from './PostContent'
+import { PostActions } from './PostActions'
+
+export function PostItem({ post, profile }) {
+  return (
+    <View style={styles.container}>
+      <Avatar uri={profile?.picture} size={40} />
+      <View style={styles.content}>
+        <Text style={styles.name}>{profile?.name || 'Anonymous'}</Text>
+        <PostContent content={post.content} />
+        <PostActions post={post} />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    padding: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  content: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  name: {
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+})
+```
+
+### 移行タイムライン
+
+```
+Phase 6: React Native 移行 (4-6週間)
+│
+├── Week 1: プロジェクトセットアップ
+│   ├── React Native プロジェクト作成
+│   ├── 依存関係インストール (nostr-tools, etc.)
+│   └── core/ ディレクトリのコードをコピー
+│
+├── Week 2: Adapter 実装
+│   ├── RNAsyncStorage
+│   ├── RNAmberSigner (Android)
+│   ├── RNClipboard
+│   └── RNNetwork
+│
+├── Week 3-4: UI コンポーネント移植
+│   ├── Navigation 構築
+│   ├── Timeline スクリーン
+│   ├── Profile スクリーン
+│   ├── Settings スクリーン
+│   └── Login スクリーン
+│
+├── Week 5: 機能実装
+│   ├── 投稿作成
+│   ├── リアクション
+│   ├── DM
+│   └── Zap
+│
+└── Week 6: テスト & リリース
+    ├── Android ビルド & テスト
+    ├── iOS ビルド & テスト (将来)
+    └── ストアリリース準備
+```
+
+### 必要な依存関係
+
+```json
+{
+  "dependencies": {
+    "react-native": "^0.73.x",
+    "@react-navigation/native": "^6.x",
+    "@react-navigation/bottom-tabs": "^6.x",
+    "@react-native-async-storage/async-storage": "^1.x",
+    "@react-native-clipboard/clipboard": "^1.x",
+    "nostr-tools": "^2.x",
+    "zustand": "^4.x",
+    "immer": "^10.x",
+    "react-native-reanimated": "^3.x",
+    "react-native-gesture-handler": "^2.x"
+  }
+}
+```
+
+### リスクと対策
+
+| リスク | 影響度 | 対策 |
+|-------|-------|------|
+| WebSocket 互換性 | 中 | react-native-url-polyfill 使用 |
+| iOS 署名対応 | 高 | 初期は Android のみサポート |
+| UI 再実装工数 | 高 | 段階的に実装、優先度高い画面から |
+| テスト工数 | 中 | Detox または Maestro でE2Eテスト |
+
+---
+
 ## 結論
 
 このプランにより：
@@ -835,4 +1211,12 @@ const pubkey = useStore((state) => state.pubkey)
 3. **テスト容易性** - Mock Adapter によりビジネスロジックの独立テスト可能
 4. **将来の拡張性** - React Native 等への移行も Adapter 追加のみで対応可能
 
-段階的な移行により、既存の Web アプリを壊すことなく、マルチプラットフォーム対応の基盤を構築できます。
+**Phase 1-5 が完了**したことで、以下のプラットフォームへの展開が可能になりました：
+
+- ✅ **Web (PWA)** - 完全サポート
+- ✅ **Android (Capacitor)** - 完全サポート
+- ✅ **iOS (Capacitor)** - 完全サポート
+- ✅ **Desktop (Electron)** - 基盤完了
+- 🔄 **React Native** - 移行可能（Phase 6 として計画）
+
+段階的な移行により、既存の Web アプリを壊すことなく、マルチプラットフォーム対応の基盤を構築できました。

--- a/src/ui/components/settings/MiniAppsSection.tsx
+++ b/src/ui/components/settings/MiniAppsSection.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface MiniApp {
+  id: string
+  name: string
+  type: 'internal' | 'external'
+  url?: string
+}
+
+interface MiniAppsSectionProps {
+  expanded?: boolean
+  onToggle?: () => void
+  onAppClick?: (app: MiniApp) => void
+}
+
+// Available mini apps that can be added to favorites
+const AVAILABLE_APPS = [
+  { id: 'scheduler', name: '調整くん' },
+  { id: 'zap', name: 'Zap設定' },
+  { id: 'relay', name: 'リレー設定' },
+  { id: 'upload', name: 'アップロード設定' },
+  { id: 'mute', name: 'ミュートリスト' },
+  { id: 'badge', name: 'プロフィールバッジ' },
+  { id: 'emoji', name: 'カスタム絵文字' },
+]
+
+export default function MiniAppsSection({ expanded = false, onToggle, onAppClick }: MiniAppsSectionProps) {
+  const [showMyApps, setShowMyApps] = useState(expanded)
+  const [favoriteApps, setFavoriteApps] = useState<MiniApp[]>([])
+  const [externalAppUrl, setExternalAppUrl] = useState('')
+  const [externalAppName, setExternalAppName] = useState('')
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedFavorites = localStorage.getItem('favoriteMiniApps')
+      if (savedFavorites) {
+        try {
+          setFavoriteApps(JSON.parse(savedFavorites))
+        } catch (e) {
+          console.error('Failed to load favorite apps:', e)
+        }
+      }
+    }
+  }, [])
+
+  const saveFavoriteApps = (apps: MiniApp[]) => {
+    setFavoriteApps(apps)
+    localStorage.setItem('favoriteMiniApps', JSON.stringify(apps))
+  }
+
+  const handleAddToFavorites = (appId: string, appName: string, appType: 'internal' | 'external' = 'internal') => {
+    const newApp: MiniApp = { id: appId, name: appName, type: appType }
+    if (!favoriteApps.some(app => app.id === appId)) {
+      saveFavoriteApps([...favoriteApps, newApp])
+    }
+  }
+
+  const handleRemoveFromFavorites = (appId: string) => {
+    saveFavoriteApps(favoriteApps.filter(app => app.id !== appId))
+  }
+
+  const handleAddExternalApp = () => {
+    const url = externalAppUrl.trim()
+    if (url && url.startsWith('http')) {
+      const appId = 'external_' + Date.now()
+      const appName = externalAppName.trim() || new URL(url).hostname
+      const newApp: MiniApp = { id: appId, name: appName, type: 'external', url }
+      saveFavoriteApps([...favoriteApps, newApp])
+      setExternalAppUrl('')
+      setExternalAppName('')
+    }
+  }
+
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index)
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+  }
+
+  const handleDrop = (dropIndex: number) => {
+    if (draggedIndex === null) return
+    const newApps = [...favoriteApps]
+    const [removed] = newApps.splice(draggedIndex, 1)
+    newApps.splice(dropIndex, 0, removed)
+    saveFavoriteApps(newApps)
+    setDraggedIndex(null)
+  }
+
+  const handleFavoriteAppClick = (app: MiniApp) => {
+    if (app.type === 'external' && app.url) {
+      window.open(app.url, '_blank', 'noopener,noreferrer')
+      return
+    }
+    onAppClick?.(app)
+  }
+
+  const handleToggle = () => {
+    setShowMyApps(!showMyApps)
+    onToggle?.()
+  }
+
+  const availableMiniApps = AVAILABLE_APPS.filter(app => !favoriteApps.some(fav => fav.id === app.id))
+
+  return (
+    <section className="bg-[var(--bg-secondary)] rounded-2xl p-4">
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+          </svg>
+          <h2 className="font-semibold text-[var(--text-primary)]">マイミニアプリ</h2>
+          {favoriteApps.length > 0 && (
+            <span className="text-sm text-[var(--text-tertiary)]">({favoriteApps.length})</span>
+          )}
+        </div>
+        <svg className={`w-5 h-5 text-[var(--text-tertiary)] transition-transform ${showMyApps ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {showMyApps && (
+        <div className="mt-4 space-y-4">
+          {/* Favorited Apps */}
+          {favoriteApps.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">お気に入りアプリ</h3>
+              <div className="space-y-2">
+                {favoriteApps.map((app, index) => (
+                  <div
+                    key={app.id}
+                    draggable
+                    onDragStart={() => handleDragStart(index)}
+                    onDragOver={handleDragOver}
+                    onDrop={() => handleDrop(index)}
+                    className="flex items-center justify-between p-3 bg-[var(--bg-tertiary)] rounded-xl hover:bg-[var(--border-color)] transition-colors"
+                  >
+                    <div
+                      className="flex items-center gap-3 flex-1 cursor-pointer"
+                      onClick={() => handleFavoriteAppClick(app)}
+                    >
+                      <svg className="w-4 h-4 text-[var(--text-tertiary)] cursor-move" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <line x1="3" y1="9" x2="21" y2="9"/>
+                        <line x1="3" y1="15" x2="21" y2="15"/>
+                      </svg>
+                      <span className="text-sm text-[var(--text-primary)]">{app.name}</span>
+                      {app.type === 'external' && (
+                        <span className="text-xs px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full">外部</span>
+                      )}
+                    </div>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleRemoveFromFavorites(app.id)
+                      }}
+                      className="text-xs text-red-400 hover:text-red-500 flex-shrink-0"
+                    >
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <line x1="18" y1="6" x2="6" y2="18"/>
+                        <line x1="6" y1="6" x2="18" y2="18"/>
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-[var(--text-tertiary)] mt-2">ドラッグして並び替えができます</p>
+            </div>
+          )}
+
+          {/* Add Nurunuru Mini App */}
+          {availableMiniApps.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">ぬるぬるミニアプリを追加</h3>
+              <div className="flex flex-wrap gap-2">
+                {availableMiniApps.map(app => (
+                  <button
+                    key={app.id}
+                    onClick={() => handleAddToFavorites(app.id, app.name)}
+                    className="px-3 py-1.5 text-sm bg-[var(--bg-tertiary)] text-[var(--text-primary)] rounded-full hover:bg-[var(--line-green)] hover:text-white transition-colors"
+                  >
+                    + {app.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Add External Mini App */}
+          <div>
+            <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">外部ミニアプリを追加</h3>
+            <div className="space-y-2">
+              <input
+                type="text"
+                value={externalAppName}
+                onChange={(e) => setExternalAppName(e.target.value)}
+                placeholder="アプリ名(例:おいくらサッツ)"
+                className="w-full input-line text-sm"
+              />
+              <div className="flex gap-2">
+                <input
+                  type="url"
+                  value={externalAppUrl}
+                  onChange={(e) => setExternalAppUrl(e.target.value)}
+                  placeholder="https://..."
+                  className="flex-1 input-line text-sm"
+                />
+                <button
+                  onClick={handleAddExternalApp}
+                  disabled={!externalAppUrl.trim().startsWith('http')}
+                  className="btn-line text-sm px-3 disabled:opacity-50"
+                >
+                  追加
+                </button>
+              </div>
+            </div>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">名前とURLを入力して外部のミニアプリを追加できます</p>
+          </div>
+
+          {favoriteApps.length === 0 && (
+            <div className="py-6 text-center text-[var(--text-tertiary)]">
+              <p className="text-sm">お気に入りのミニアプリはありません</p>
+              <p className="text-xs mt-1">上から追加してください</p>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/ui/components/settings/MuteSection.tsx
+++ b/src/ui/components/settings/MuteSection.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  fetchMuteList,
+  removeFromMuteList,
+  fetchEvents,
+  parseProfile,
+  shortenPubkey,
+  getDefaultRelay
+} from '@/lib/nostr'
+
+interface MuteSectionProps {
+  pubkey: string | null
+  expanded?: boolean
+  onToggle?: () => void
+}
+
+interface MuteList {
+  pubkeys: string[]
+  eventIds: string[]
+  hashtags: string[]
+  words: string[]
+}
+
+interface Profile {
+  name?: string
+  picture?: string
+  [key: string]: any
+}
+
+export default function MuteSection({ pubkey, expanded = false, onToggle }: MuteSectionProps) {
+  const [showSettings, setShowSettings] = useState(expanded)
+  const [muteList, setMuteList] = useState<MuteList>({ pubkeys: [], eventIds: [], hashtags: [], words: [] })
+  const [mutedProfiles, setMutedProfiles] = useState<Record<string, Profile>>({})
+  const [loading, setLoading] = useState(true)
+  const [removing, setRemoving] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (pubkey) {
+      loadMuteList()
+    } else {
+      setLoading(false)
+    }
+  }, [pubkey])
+
+  const loadMuteList = async () => {
+    if (!pubkey) return
+    setLoading(true)
+    try {
+      const list = await fetchMuteList(pubkey)
+      setMuteList(list)
+
+      if (list.pubkeys.length > 0) {
+        const profileEvents = await fetchEvents(
+          { kinds: [0], authors: list.pubkeys, limit: list.pubkeys.length },
+          [getDefaultRelay()]
+        ) as { pubkey: string; [key: string]: any }[]
+        const profiles: Record<string, Profile> = {}
+        for (const event of profileEvents) {
+          const profile = parseProfile(event)
+          if (profile) {
+            profiles[event.pubkey] = profile
+          }
+        }
+        setMutedProfiles(profiles)
+      }
+    } catch (e) {
+      console.error('Failed to load mute list:', e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleUnmute = async (type: 'pubkey' | 'hashtag' | 'word', value: string) => {
+    if (!pubkey || removing) return
+    setRemoving(value)
+
+    try {
+      await removeFromMuteList(pubkey, type, value)
+      if (type === 'pubkey') {
+        setMuteList(prev => ({
+          ...prev,
+          pubkeys: prev.pubkeys.filter(p => p !== value)
+        }))
+      } else if (type === 'hashtag') {
+        setMuteList(prev => ({
+          ...prev,
+          hashtags: prev.hashtags.filter(h => h !== value)
+        }))
+      } else if (type === 'word') {
+        setMuteList(prev => ({
+          ...prev,
+          words: prev.words.filter(w => w !== value)
+        }))
+      }
+    } catch (e) {
+      console.error('Failed to unmute:', e)
+    } finally {
+      setRemoving(null)
+    }
+  }
+
+  const handleToggle = () => {
+    setShowSettings(!showSettings)
+    onToggle?.()
+  }
+
+  const totalMuted = muteList.pubkeys.length + muteList.hashtags.length + muteList.words.length
+
+  return (
+    <section id="mute-section" className="bg-[var(--bg-secondary)] rounded-2xl p-4">
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/>
+          </svg>
+          <h2 className="font-semibold text-[var(--text-primary)]">ミュートリスト</h2>
+          {totalMuted > 0 && (
+            <span className="text-sm text-[var(--text-tertiary)]">
+              ({totalMuted}件)
+            </span>
+          )}
+        </div>
+        <svg className={`w-5 h-5 text-[var(--text-tertiary)] transition-transform ${showSettings ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {showSettings && (
+        <div className="mt-4">
+          {loading ? (
+            <div className="py-8 text-center text-[var(--text-tertiary)]">
+              読み込み中...
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Muted Users */}
+              {muteList.pubkeys.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">ミュートしたユーザー</h3>
+                  <div className="space-y-2">
+                    {muteList.pubkeys.map(pk => {
+                      const profile = mutedProfiles[pk]
+                      return (
+                        <div key={pk} className="flex items-center justify-between p-2 bg-[var(--bg-tertiary)] rounded-xl">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <div className="w-8 h-8 rounded-full overflow-hidden bg-[var(--bg-primary)] flex-shrink-0">
+                              {profile?.picture ? (
+                                <img
+                                  src={profile.picture}
+                                  alt=""
+                                  className="w-full h-full object-cover"
+                                  referrerPolicy="no-referrer"
+                                  onError={(e) => {
+                                    const target = e.target as HTMLImageElement
+                                    target.style.display = 'none'
+                                    if (target.parentElement) {
+                                      target.parentElement.innerHTML = '<div class="w-full h-full flex items-center justify-center"><svg class="w-4 h-4 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>'
+                                    }
+                                  }}
+                                />
+                              ) : (
+                                <div className="w-full h-full flex items-center justify-center">
+                                  <svg className="w-4 h-4 text-[var(--text-tertiary)]" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+                                  </svg>
+                                </div>
+                              )}
+                            </div>
+                            <span className="text-sm text-[var(--text-primary)] truncate">
+                              {profile?.name || shortenPubkey(pk, 8)}
+                            </span>
+                          </div>
+                          <button
+                            onClick={() => handleUnmute('pubkey', pk)}
+                            disabled={removing === pk}
+                            className="text-xs text-red-400 hover:underline disabled:opacity-50 px-2"
+                          >
+                            {removing === pk ? '...' : '解除'}
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Muted Hashtags */}
+              {muteList.hashtags.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">ミュートしたハッシュタグ</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {muteList.hashtags.map(tag => (
+                      <div key={tag} className="flex items-center gap-1 px-3 py-1.5 bg-[var(--bg-tertiary)] rounded-full">
+                        <span className="text-sm text-[var(--text-primary)]">#{tag}</span>
+                        <button
+                          onClick={() => handleUnmute('hashtag', tag)}
+                          disabled={removing === tag}
+                          className="text-red-400 hover:text-red-500 disabled:opacity-50 ml-1"
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <line x1="18" y1="6" x2="6" y2="18"/>
+                            <line x1="6" y1="6" x2="18" y2="18"/>
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Muted Words */}
+              {muteList.words.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-[var(--text-secondary)] mb-2">ミュートしたワード</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {muteList.words.map(word => (
+                      <div key={word} className="flex items-center gap-1 px-3 py-1.5 bg-[var(--bg-tertiary)] rounded-full">
+                        <span className="text-sm text-[var(--text-primary)]">{word}</span>
+                        <button
+                          onClick={() => handleUnmute('word', word)}
+                          disabled={removing === word}
+                          className="text-red-400 hover:text-red-500 disabled:opacity-50 ml-1"
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <line x1="18" y1="6" x2="6" y2="18"/>
+                            <line x1="6" y1="6" x2="18" y2="18"/>
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Empty state */}
+              {totalMuted === 0 && (
+                <div className="py-6 text-center text-[var(--text-tertiary)]">
+                  <p className="text-sm">ミュートしているユーザーやワードはありません</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/ui/components/settings/NosskeySettings.tsx
+++ b/src/ui/components/settings/NosskeySettings.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { nip19 } from 'nostr-tools'
+
+interface NosskeySettingsProps {
+  pubkey: string
+}
+
+export default function NosskeySettings({ pubkey }: NosskeySettingsProps) {
+  const [showSettings, setShowSettings] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [exportedNsec, setExportedNsec] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [autoSign, setAutoSign] = useState(true)
+  const [hasExportedKey, setHasExportedKey] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if ((window as any).nostrPrivateKey) {
+        setHasExportedKey(true)
+      }
+      const savedAutoSign = localStorage.getItem('nurunuru_auto_sign')
+      setAutoSign(savedAutoSign !== 'false')
+    }
+  }, [])
+
+  const hexToBytes = (hex: string): Uint8Array => {
+    const bytes = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < hex.length; i += 2) {
+      bytes[i / 2] = parseInt(hex.substr(i, 2), 16)
+    }
+    return bytes
+  }
+
+  const handleAutoSignChange = (enabled: boolean) => {
+    setAutoSign(enabled)
+    localStorage.setItem('nurunuru_auto_sign', enabled ? 'true' : 'false')
+  }
+
+  const handleExportKey = async () => {
+    if (!(window as any).nosskeyManager) {
+      alert('Nosskeyマネージャーが見つかりません。再ログインしてください。')
+      return
+    }
+
+    setExporting(true)
+    try {
+      const manager = (window as any).nosskeyManager
+      const keyInfo = manager.getCurrentKeyInfo()
+
+      if (!keyInfo) {
+        throw new Error('鍵情報が見つかりません。再ログインしてください。')
+      }
+
+      manager.setCacheOptions({ enabled: true, timeoutMs: 3600000 })
+      const privateKeyHex = await manager.exportNostrKey(keyInfo)
+
+      if (!privateKeyHex) {
+        throw new Error('秘密鍵を取得できませんでした')
+      }
+
+      const nsec = nip19.nsecEncode(hexToBytes(privateKeyHex))
+      setExportedNsec(nsec)
+      ;(window as any).nostrPrivateKey = privateKeyHex
+      setHasExportedKey(true)
+
+    } catch (e: any) {
+      console.error('Export error:', e)
+      if (e.name === 'NotAllowedError') {
+        alert('パスキー認証がキャンセルされました')
+      } else {
+        alert('秘密鍵のエクスポートに失敗しました: ' + e.message)
+      }
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const handleCopyNsec = async () => {
+    if (!exportedNsec) return
+    try {
+      await navigator.clipboard.writeText(exportedNsec)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 3000)
+    } catch (e) {
+      const textarea = document.createElement('textarea')
+      textarea.value = exportedNsec
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 3000)
+    }
+  }
+
+  const handleCloseExport = () => {
+    setExportedNsec(null)
+    setCopied(false)
+  }
+
+  return (
+    <section className="bg-[var(--bg-secondary)] rounded-2xl p-4">
+      <button
+        onClick={() => setShowSettings(!showSettings)}
+        className="w-full flex items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path d="M12 2a4 4 0 014 4v2h2a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V10a2 2 0 012-2h2V6a4 4 0 014-4z"/>
+            <circle cx="12" cy="15" r="1"/>
+          </svg>
+          <h2 className="font-semibold text-[var(--text-primary)]">パスキー設定</h2>
+        </div>
+        <svg className={`w-5 h-5 text-[var(--text-tertiary)] transition-transform ${showSettings ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {showSettings && (
+        <div className="mt-4 space-y-4">
+          {/* Auto Sign Setting */}
+          <div className="bg-[var(--bg-tertiary)] p-3 rounded-xl">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-[var(--text-primary)]">自動署名</p>
+                <p className="text-xs text-[var(--text-tertiary)]">
+                  {hasExportedKey
+                    ? (autoSign ? '投稿時に生体認証なし' : '毎回生体認証を要求')
+                    : '秘密鍵をエクスポートすると有効化'}
+                </p>
+              </div>
+              <button
+                onClick={() => handleAutoSignChange(!autoSign)}
+                disabled={!hasExportedKey}
+                className={`relative w-12 h-6 rounded-full transition-colors ${
+                  autoSign && hasExportedKey ? 'bg-[var(--line-green)]' : 'bg-[var(--border-color)]'
+                } ${!hasExportedKey ? 'opacity-50' : ''}`}
+              >
+                <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                  autoSign && hasExportedKey ? 'translate-x-6' : 'translate-x-0'
+                }`} />
+              </button>
+            </div>
+          </div>
+
+          {/* Export Key */}
+          {!exportedNsec ? (
+            <div>
+              <p className="text-xs text-[var(--text-tertiary)] mb-3">
+                秘密鍵をエクスポートして他のアプリで使用できます。
+              </p>
+              <button
+                onClick={handleExportKey}
+                disabled={exporting}
+                className="w-full py-3 text-sm disabled:opacity-50 btn-secondary"
+              >
+                {exporting ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
+                      <path d="M12 2a10 10 0 019.5 7" strokeLinecap="round"/>
+                    </svg>
+                    認証中...
+                  </span>
+                ) : (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                      <polyline points="17 8 12 3 7 8"/>
+                      <line x1="12" y1="3" x2="12" y2="15"/>
+                    </svg>
+                    秘密鍵を表示
+                  </span>
+                )}
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 rounded-xl">
+                <p className="text-xs text-red-600 dark:text-red-400 font-medium">
+                  ⚠️ 秘密鍵は他人に見せないでください
+                </p>
+              </div>
+
+              <div className="bg-[var(--bg-tertiary)] p-3 rounded-xl">
+                <p className="text-xs text-[var(--text-tertiary)] mb-2">秘密鍵 (nsec)</p>
+                <div className="bg-[var(--bg-primary)] p-2 rounded-lg border border-[var(--border-color)]">
+                  <p className="text-xs font-mono text-[var(--text-primary)] break-all select-all">
+                    {exportedNsec}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  onClick={handleCopyNsec}
+                  className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                    copied
+                      ? 'bg-[var(--line-green)] text-white'
+                      : 'btn-secondary'
+                  }`}
+                >
+                  {copied ? '✓ コピーしました' : 'コピー'}
+                </button>
+                <button
+                  onClick={handleCloseExport}
+                  className="flex-1 btn-secondary py-2 text-sm"
+                >
+                  閉じる
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/ui/components/settings/RelaySection.tsx
+++ b/src/ui/components/settings/RelaySection.tsx
@@ -1,0 +1,419 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  getDefaultRelay,
+  setDefaultRelay,
+  canSign,
+  publishRelayListMetadata
+} from '@/lib/nostr'
+import {
+  autoDetectRelays,
+  formatDistance,
+  REGION_COORDINATES,
+  selectRelaysByRegion,
+  loadSelectedRegion
+} from '@/lib/geohash'
+
+// Popular relay list
+const KNOWN_RELAYS = [
+  { url: 'wss://yabu.me', name: 'やぶみ (デフォルト)', region: 'JP' },
+  { url: 'wss://relay-jp.nostr.wirednet.jp', name: 'WiredNet JP', region: 'JP' },
+  { url: 'wss://r.kojira.io', name: 'Kojira', region: 'JP' },
+  { url: 'wss://nos.lol', name: 'nos.lol', region: 'Global' },
+  { url: 'wss://relay.damus.io', name: 'Damus', region: 'Global' },
+  { url: 'wss://relay.snort.social', name: 'Snort', region: 'Global' },
+  { url: 'wss://nostr.wine', name: 'nostr.wine (有料)', region: 'Global' },
+  { url: 'wss://relay.nostr.bg', name: 'nostr.bg', region: 'EU' },
+]
+
+interface RelaySectionProps {
+  pubkey: string | null
+  expanded?: boolean
+  onToggle?: () => void
+}
+
+interface NearestRelay {
+  url: string
+  name: string
+  region: string
+  distance: number
+}
+
+interface Nip65Config {
+  outbox?: NearestRelay[]
+  inbox?: NearestRelay[]
+  discover?: { url: string; name: string }[]
+  combined?: { url: string; read: boolean; write: boolean }[]
+}
+
+interface Region {
+  id: string
+  name: string
+  country: string
+}
+
+export default function RelaySection({ pubkey, expanded = false, onToggle }: RelaySectionProps) {
+  const [showSettings, setShowSettings] = useState(expanded)
+  const [currentRelay, setCurrentRelay] = useState('wss://yabu.me')
+  const [detectingLocation, setDetectingLocation] = useState(false)
+  const [userGeohash, setUserGeohash] = useState<string | null>(null)
+  const [userLocation, setUserLocation] = useState<any>(null)
+  const [selectedRegion, setSelectedRegion] = useState<Region | null>(null)
+  const [nearestRelays, setNearestRelays] = useState<NearestRelay[]>([])
+  const [nip65Config, setNip65Config] = useState<Nip65Config | null>(null)
+  const [showNip65Details, setShowNip65Details] = useState(false)
+  const [publishingNip65, setPublishingNip65] = useState(false)
+
+  useEffect(() => {
+    setCurrentRelay(getDefaultRelay())
+
+    const savedRegionId = loadSelectedRegion()
+    if (savedRegionId) {
+      const result = selectRelaysByRegion(savedRegionId) as any
+      if (result.region) {
+        setSelectedRegion(result.region as Region)
+        setUserGeohash(result.geohash as string)
+        setUserLocation(result.location)
+        setNip65Config(result.nip65Config as Nip65Config)
+        setNearestRelays((result.nearestRelays || []) as NearestRelay[])
+      }
+    }
+  }, [])
+
+  const handleChangeRelay = (relayUrl: string) => {
+    setCurrentRelay(relayUrl)
+    setDefaultRelay(relayUrl)
+  }
+
+  const handleSelectNearestRelay = (relay: NearestRelay) => {
+    handleChangeRelay(relay.url)
+
+    if (nip65Config) {
+      const newOutbox = [relay, ...nip65Config.outbox!.filter(r => r.url !== relay.url)].slice(0, 5)
+      const newCombined = [
+        { url: relay.url, read: true, write: true },
+        ...nip65Config.combined!.filter(r => r.url !== relay.url)
+      ]
+      setNip65Config({
+        ...nip65Config,
+        outbox: newOutbox,
+        combined: newCombined
+      })
+    }
+  }
+
+  const handleAutoDetectLocation = async () => {
+    setDetectingLocation(true)
+    try {
+      const result = await autoDetectRelays() as any
+      if (result.geohash) {
+        setUserGeohash(result.geohash as string)
+        setUserLocation(result.location)
+        setNip65Config(result.nip65Config as Nip65Config)
+        setNearestRelays((result.nearestRelays || []) as NearestRelay[])
+        setSelectedRegion(null)
+
+        if (result.nip65Config?.outbox?.length > 0) {
+          handleChangeRelay(result.nip65Config.outbox[0].url)
+        } else if (result.relays?.length > 0) {
+          handleChangeRelay(result.relays[0].url)
+        }
+      } else if (result.error) {
+        alert(`位置情報の取得に失敗しました: ${result.error}`)
+      }
+    } catch (e) {
+      console.error('Location detection failed:', e)
+      alert('位置情報の取得に失敗しました。ブラウザの位置情報設定を確認してください。')
+    } finally {
+      setDetectingLocation(false)
+    }
+  }
+
+  const handleSelectRegion = (regionId: string) => {
+    const result = selectRelaysByRegion(regionId) as any
+    if (result.region) {
+      setSelectedRegion(result.region as Region)
+      setUserGeohash(result.geohash as string)
+      setUserLocation(result.location)
+      setNip65Config(result.nip65Config as Nip65Config)
+      setNearestRelays((result.nearestRelays || []) as NearestRelay[])
+
+      if (result.nip65Config?.outbox?.length > 0) {
+        handleChangeRelay(result.nip65Config.outbox[0].url)
+      }
+    }
+  }
+
+  const handlePublishRelayList = async () => {
+    if (!pubkey || !canSign()) {
+      alert('リレーリストを発行するにはログインが必要です')
+      return
+    }
+    setPublishingNip65(true)
+    try {
+      let relayList
+      if (nip65Config?.combined?.length && nip65Config.combined.length > 0) {
+        relayList = nip65Config.combined
+      } else {
+        relayList = [{ url: currentRelay, read: true, write: true }]
+      }
+
+      const result = await publishRelayListMetadata(relayList) as { success: boolean }
+      if (result.success) {
+        const outboxCount = relayList.filter(r => r.write).length
+        const inboxCount = relayList.filter(r => r.read).length
+        alert(`リレーリストを発行しました (NIP-65)\nOutbox: ${outboxCount}リレー\nInbox: ${inboxCount}リレー`)
+      }
+    } catch (e: any) {
+      console.error('Failed to publish relay list:', e)
+      alert('リレーリストの発行に失敗しました: ' + e.message)
+    } finally {
+      setPublishingNip65(false)
+    }
+  }
+
+  const handleToggle = () => {
+    setShowSettings(!showSettings)
+    onToggle?.()
+  }
+
+  return (
+    <section id="relay-section" className="bg-[var(--bg-secondary)] rounded-2xl p-4">
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <circle cx="12" cy="12" r="3"/>
+            <path d="M12 2v4m0 12v4M2 12h4m12 0h4"/>
+            <circle cx="12" cy="12" r="8" strokeDasharray="4 2"/>
+          </svg>
+          <h2 className="font-semibold text-[var(--text-primary)]">リレー</h2>
+          <span className="text-xs text-[var(--text-tertiary)] truncate max-w-[120px]">{currentRelay.replace('wss://', '')}</span>
+        </div>
+        <svg className={`w-5 h-5 text-[var(--text-tertiary)] transition-transform ${showSettings ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {showSettings && (
+        <div className="mt-4 space-y-4">
+          {/* Region Display */}
+          <div className="p-3 bg-[var(--line-green)] bg-opacity-10 rounded-xl border border-[var(--line-green)]">
+            <p className="text-xs text-[var(--text-tertiary)] mb-1">地域</p>
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              {selectedRegion ? selectedRegion.name : (userGeohash ? 'GPS検出' : '未設定')}
+            </p>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">
+              メインリレー: {currentRelay.replace('wss://', '')}
+            </p>
+          </div>
+
+          {/* Region Selection */}
+          <div className="p-3 bg-[var(--bg-tertiary)] rounded-xl">
+            <p className="text-sm font-medium text-[var(--text-secondary)] mb-2">地域を選択</p>
+            <p className="text-xs text-[var(--text-tertiary)] mb-3">
+              地域を選択すると最適なリレーが自動設定されます
+            </p>
+            <select
+              value={selectedRegion?.id || ''}
+              onChange={(e) => e.target.value && handleSelectRegion(e.target.value)}
+              className="w-full py-2.5 px-3 bg-[var(--bg-secondary)] text-[var(--text-primary)] rounded-lg text-sm border border-[var(--border-color)] focus:border-[var(--line-green)] focus:outline-none"
+            >
+              <option value="">地域を選択...</option>
+              <optgroup label="日本">
+                {REGION_COORDINATES.filter((r: any) => r.country === 'JP').map((r: any) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </optgroup>
+              <optgroup label="アジア">
+                {REGION_COORDINATES.filter((r: any) => ['SG', 'TW', 'KR', 'CN', 'IN'].includes(r.country)).map((r: any) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </optgroup>
+              <optgroup label="北米">
+                {REGION_COORDINATES.filter((r: any) => ['US', 'CA'].includes(r.country)).map((r: any) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </optgroup>
+              <optgroup label="ヨーロッパ">
+                {REGION_COORDINATES.filter((r: any) => ['EU', 'UK'].includes(r.country)).map((r: any) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </optgroup>
+              <optgroup label="その他">
+                {REGION_COORDINATES.filter((r: any) => ['AU', 'BR', 'Global'].includes(r.country)).map((r: any) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </optgroup>
+            </select>
+
+            {/* GPS auto-detect button */}
+            <div className="mt-3 pt-3 border-t border-[var(--border-color)]">
+              <button
+                onClick={handleAutoDetectLocation}
+                disabled={detectingLocation}
+                className="w-full py-2 bg-[var(--bg-secondary)] hover:bg-[var(--border-color)] text-[var(--text-secondary)] rounded-lg text-xs font-medium transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {detectingLocation ? (
+                  <>
+                    <svg className="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
+                      <path d="M12 2a10 10 0 019.5 7" strokeLinecap="round"/>
+                    </svg>
+                    位置情報を取得中...
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="10" r="3"/>
+                      <path d="M12 21.7C17.3 17 20 13 20 10a8 8 0 1 0-16 0c0 3 2.7 7 8 11.7z"/>
+                    </svg>
+                    GPSで自動検出
+                  </>
+                )}
+              </button>
+            </div>
+
+            {/* Show nearest relays with distance */}
+            {nearestRelays.length > 0 && (
+              <div className="mt-3 pt-3 border-t border-[var(--border-color)]">
+                <p className="text-xs text-[var(--text-tertiary)] mb-2">最寄りのリレー:</p>
+                <div className="space-y-1">
+                  {nearestRelays.slice(0, 5).map(relay => (
+                    <button
+                      key={relay.url}
+                      onClick={() => handleSelectNearestRelay(relay)}
+                      className={`w-full text-left px-3 py-2 rounded-lg text-xs transition-colors flex items-center justify-between ${
+                        currentRelay === relay.url
+                          ? 'bg-[var(--line-green)] text-white'
+                          : 'bg-[var(--bg-secondary)] text-[var(--text-primary)] hover:bg-[var(--border-color)]'
+                      }`}
+                    >
+                      <span>{relay.name} ({relay.region})</span>
+                      <span className="opacity-70">{formatDistance(relay.distance)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* NIP-65 Outbox Model Configuration */}
+            {nip65Config && (
+              <div className="mt-3 pt-3 border-t border-[var(--border-color)]">
+                <button
+                  onClick={() => setShowNip65Details(!showNip65Details)}
+                  className="w-full flex items-center justify-between text-xs text-[var(--text-secondary)] mb-2"
+                >
+                  <span className="font-medium">NIP-65 Outbox Model 設定</span>
+                  <svg className={`w-4 h-4 transition-transform ${showNip65Details ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polyline points="6,9 12,15 18,9"/>
+                  </svg>
+                </button>
+
+                {showNip65Details && (
+                  <div className="space-y-3">
+                    {nip65Config.outbox && nip65Config.outbox.length > 0 && (
+                      <div>
+                        <p className="text-xs text-[var(--text-tertiary)] mb-1 flex items-center gap-1">
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path d="M12 19l7-7 3 3-7 7-3-3z"/>
+                            <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"/>
+                          </svg>
+                          Outbox (投稿先) - {nip65Config.outbox.length}リレー
+                        </p>
+                        <div className="space-y-1">
+                          {nip65Config.outbox.map(relay => (
+                            <div key={relay.url} className="px-2 py-1 bg-green-500 bg-opacity-10 rounded text-xs text-[var(--text-primary)] flex justify-between">
+                              <span className="truncate">{relay.name}</span>
+                              <span className="text-green-500 opacity-70">{formatDistance(relay.distance)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {nip65Config.inbox && nip65Config.inbox.length > 0 && (
+                      <div>
+                        <p className="text-xs text-[var(--text-tertiary)] mb-1 flex items-center gap-1">
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+                          </svg>
+                          Inbox (受信先) - {nip65Config.inbox.length}リレー
+                        </p>
+                        <div className="space-y-1">
+                          {nip65Config.inbox.map(relay => (
+                            <div key={relay.url} className="px-2 py-1 bg-blue-500 bg-opacity-10 rounded text-xs text-[var(--text-primary)] flex justify-between">
+                              <span className="truncate">{relay.name}</span>
+                              <span className="text-blue-500 opacity-70">{formatDistance(relay.distance)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {nip65Config.discover && nip65Config.discover.length > 0 && (
+                      <div>
+                        <p className="text-xs text-[var(--text-tertiary)] mb-1 flex items-center gap-1">
+                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <circle cx="11" cy="11" r="8"/>
+                            <path d="M21 21l-4.35-4.35"/>
+                          </svg>
+                          Discover (NIP-65検索) - {nip65Config.discover.length}リレー
+                        </p>
+                        <div className="space-y-1">
+                          {nip65Config.discover.map(relay => (
+                            <div key={relay.url} className="px-2 py-1 bg-purple-500 bg-opacity-10 rounded text-xs text-[var(--text-primary)]">
+                              <span className="truncate">{relay.name}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Publish to NIP-65 */}
+          {pubkey && canSign() && (
+            <div className="p-3 bg-[var(--bg-tertiary)] rounded-xl">
+              <p className="text-sm font-medium text-[var(--text-secondary)] mb-2">リレーリストを発行 (NIP-65)</p>
+              <p className="text-xs text-[var(--text-tertiary)] mb-3">
+                現在のリレー設定を他のクライアントと共有できます
+              </p>
+              <button
+                onClick={handlePublishRelayList}
+                disabled={publishingNip65}
+                className="w-full py-2.5 bg-purple-500 hover:bg-purple-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {publishingNip65 ? (
+                  <>
+                    <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
+                      <path d="M12 2a10 10 0 019.5 7" strokeLinecap="round"/>
+                    </svg>
+                    発行中...
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M12 19l7-7 3 3-7 7-3-3z"/>
+                      <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"/>
+                      <path d="M2 2l7.586 7.586"/>
+                      <circle cx="11" cy="11" r="2"/>
+                    </svg>
+                    リレーリストを発行
+                  </>
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/ui/components/settings/UploadSection.tsx
+++ b/src/ui/components/settings/UploadSection.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { getUploadServer, setUploadServer } from '@/lib/nostr'
+
+const UPLOAD_SERVERS = [
+  { id: 'nostr.build', name: 'nostr.build', url: 'nostr.build' },
+  { id: 'share.yabu.me', name: 'やぶみ', url: 'share.yabu.me' },
+  { id: 'blossom.nostr', name: 'Blossom (nostr.build)', url: 'https://blossom.nostr.build' },
+]
+
+interface UploadSectionProps {
+  expanded?: boolean
+  onToggle?: () => void
+}
+
+export default function UploadSection({ expanded = false, onToggle }: UploadSectionProps) {
+  const [showSettings, setShowSettings] = useState(expanded)
+  const [uploadServerState, setUploadServerState] = useState('nostr.build')
+  const [customBlossomUrl, setCustomBlossomUrl] = useState('')
+
+  useEffect(() => {
+    setUploadServerState(getUploadServer())
+  }, [])
+
+  const handleSelectUploadServer = (server: string) => {
+    setUploadServerState(server)
+    setUploadServer(server)
+  }
+
+  const handleSetCustomBlossom = () => {
+    const url = customBlossomUrl.trim()
+    if (url && url.startsWith('https://')) {
+      setUploadServerState(url)
+      setUploadServer(url)
+      setCustomBlossomUrl('')
+    }
+  }
+
+  const handleToggle = () => {
+    setShowSettings(!showSettings)
+    onToggle?.()
+  }
+
+  return (
+    <section id="upload-section" className="bg-[var(--bg-secondary)] rounded-2xl p-4">
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-[var(--text-secondary)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+            <circle cx="8.5" cy="8.5" r="1.5"/>
+            <polyline points="21 15 16 10 5 21"/>
+          </svg>
+          <h2 className="font-semibold text-[var(--text-primary)]">画像アップロード</h2>
+        </div>
+        <svg className={`w-5 h-5 text-[var(--text-tertiary)] transition-transform ${showSettings ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {showSettings && (
+        <div className="mt-4 space-y-3">
+          <p className="text-xs text-[var(--text-tertiary)]">
+            プロフィール画像のアップロード先
+          </p>
+
+          {/* Preset servers */}
+          <div className="space-y-2">
+            {UPLOAD_SERVERS.map(server => (
+              <button
+                key={server.id}
+                onClick={() => handleSelectUploadServer(server.url)}
+                className={`w-full flex items-center justify-between p-3 rounded-xl transition-all ${
+                  uploadServerState === server.url
+                    ? 'bg-[var(--line-green)] text-white'
+                    : 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]'
+                }`}
+              >
+                <span className="text-sm font-medium">{server.name}</span>
+                {uploadServerState === server.url && (
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polyline points="20 6 9 17 4 12"/>
+                  </svg>
+                )}
+              </button>
+            ))}
+          </div>
+
+          {/* Custom Blossom URL */}
+          <div className="pt-2">
+            <p className="text-xs text-[var(--text-tertiary)] mb-2">
+              カスタムBlossomサーバー
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={customBlossomUrl}
+                onChange={(e) => setCustomBlossomUrl(e.target.value)}
+                placeholder="https://..."
+                className="flex-1 input-line text-sm"
+              />
+              <button
+                onClick={handleSetCustomBlossom}
+                className="btn-line text-sm px-3"
+              >
+                設定
+              </button>
+            </div>
+          </div>
+
+          <p className="text-xs text-[var(--text-tertiary)] pt-2">
+            現在: {uploadServerState}
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/ui/components/settings/index.ts
+++ b/src/ui/components/settings/index.ts
@@ -4,3 +4,8 @@
 
 export { ZapSettings } from './ZapSettings'
 export { AccountSection } from './AccountSection'
+export { default as NosskeySettings } from './NosskeySettings'
+export { default as RelaySection } from './RelaySection'
+export { default as MuteSection } from './MuteSection'
+export { default as UploadSection } from './UploadSection'
+export { default as MiniAppsSection } from './MiniAppsSection'

--- a/src/ui/components/timeline/TimelineEmpty.tsx
+++ b/src/ui/components/timeline/TimelineEmpty.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+type TimelineMode = 'global' | 'following'
+
+interface TimelineEmptyProps {
+  mode: TimelineMode
+  hasFollows: boolean
+  hasError?: boolean
+  onRetry?: () => void
+}
+
+export default function TimelineEmpty({ mode, hasFollows, hasError = false, onRetry }: TimelineEmptyProps) {
+  return (
+    <div className="error-friendly animate-fadeIn">
+      <div className="error-friendly-icon">
+        {hasError ? (
+          /* Connection error - friendly icon */
+          <svg className="w-10 h-10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
+            <line x1="9" y1="9" x2="9.01" y2="9"/>
+            <line x1="15" y1="9" x2="15.01" y2="9"/>
+          </svg>
+        ) : mode === 'following' ? (
+          <svg className="w-10 h-10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+            <circle cx="9" cy="7" r="4"/>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+          </svg>
+        ) : (
+          <svg className="w-10 h-10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+            <line x1="3" y1="9" x2="21" y2="9"/>
+            <line x1="9" y1="21" x2="9" y2="9"/>
+          </svg>
+        )}
+      </div>
+
+      {/* Encouraging message */}
+      <h2 className="error-friendly-title">
+        {hasError
+          ? 'うまく接続できませんでした'
+          : mode === 'following'
+            ? (!hasFollows ? 'まだ誰もフォローしていません' : 'まだ投稿がないようです')
+            : 'まだ投稿がありません'}
+      </h2>
+
+      <p className="error-friendly-message">
+        {hasError
+          ? '通信状態を確認して、もう一度お試しください'
+          : mode === 'following'
+            ? (!hasFollows ? '素敵な人を見つけてフォローしてみましょう' : 'しばらくお待ちいただくか、更新してみてください')
+            : '新しい投稿がまもなく届くかもしれません'}
+      </p>
+
+      {hasError && onRetry ? (
+        <button
+          onClick={onRetry}
+          className="retry-button mt-4"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="23 4 23 10 17 10"/>
+            <path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/>
+          </svg>
+          もう一度試す
+        </button>
+      ) : mode === 'following' && !hasFollows && (
+        <div className="error-friendly-hint mt-4">
+          💡 プロフィールページでユーザーをフォローしてみましょう
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Desktop version with simpler styling
+export function TimelineEmptyDesktop({ hasFollows }: { hasFollows: boolean }) {
+  return (
+    <div className="px-4 py-16 text-center">
+      <p className="text-[var(--text-tertiary)]">
+        {!hasFollows ? 'まだ誰もフォローしていません' : 'フォロー中のユーザーの投稿がありません'}
+      </p>
+      {!hasFollows && (
+        <p className="text-xs text-[var(--text-tertiary)] mt-2">
+          プロフィールページでユーザーをフォローしてみましょう
+        </p>
+      )}
+    </div>
+  )
+}
+
+// Global timeline empty state for desktop
+export function TimelineEmptyGlobal() {
+  return (
+    <div className="empty-friendly">
+      <div className="empty-friendly-icon">📭</div>
+      <p className="empty-friendly-text">まだ投稿がありません<br/>新しい投稿がまもなく届くかもしれません</p>
+    </div>
+  )
+}

--- a/src/ui/components/timeline/TimelineList.tsx
+++ b/src/ui/components/timeline/TimelineList.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import PostItemOriginal from '@/components/PostItem'
+
+// Cast PostItem to any to avoid TypeScript issues with JavaScript component
+const PostItem = PostItemOriginal as any
+
+interface Profile {
+  name?: string
+  picture?: string
+  lud16?: string
+  [key: string]: any
+}
+
+interface Post {
+  id: string
+  pubkey: string
+  content: string
+  created_at: number
+  tags: string[][]
+  _isRepost?: boolean
+  _repostedBy?: string
+  _repostTime?: number
+  _repostId?: string
+}
+
+interface TimelineListProps {
+  posts: Post[]
+  profiles: Record<string, Profile>
+  reactions: Record<string, number>
+  userReactions: Set<string>
+  userReposts: Set<string>
+  userReactionIds: Record<string, string>
+  userRepostIds: Record<string, string>
+  birdwatchLabels: Record<string, any[]>
+  mutedPubkeys: Set<string>
+  zapAnimating: string | null
+  likeAnimating: string | null
+  pubkey: string | null
+  showNotInterested?: boolean
+  onLike: (event: Post) => void
+  onUnlike: (event: Post, reactionEventId: string) => void
+  onRepost: (event: Post) => void
+  onUnrepost: (event: Post, repostEventId: string) => void
+  onZap: (event: Post) => void
+  onZapLongPress: (event: Post) => void
+  onZapLongPressEnd: () => void
+  onAvatarClick: (pubkey: string, profile?: Profile) => void
+  onHashtagClick: (hashtag: string) => void
+  onMute: (pubkey: string) => void
+  onDelete: (eventId: string) => void
+  onReport?: (reportData: any) => void
+  onBirdwatch?: (data: any) => void
+  onBirdwatchRate?: (labelEventId: string, rating: string) => void
+  onNotInterested?: (eventId: string, authorPubkey: string) => void
+}
+
+export default function TimelineList({
+  posts,
+  profiles,
+  reactions,
+  userReactions,
+  userReposts,
+  userReactionIds,
+  userRepostIds,
+  birdwatchLabels,
+  mutedPubkeys,
+  zapAnimating,
+  likeAnimating,
+  pubkey,
+  showNotInterested = false,
+  onLike,
+  onUnlike,
+  onRepost,
+  onUnrepost,
+  onZap,
+  onZapLongPress,
+  onZapLongPressEnd,
+  onAvatarClick,
+  onHashtagClick,
+  onMute,
+  onDelete,
+  onReport,
+  onBirdwatch,
+  onBirdwatchRate,
+  onNotInterested,
+}: TimelineListProps) {
+  const filteredPosts = posts.filter(post => !mutedPubkeys.has(post.pubkey))
+
+  return (
+    <div className="divide-y divide-[var(--border-color)]">
+      {filteredPosts.map((post, index) => {
+        const profile = profiles[post.pubkey]
+        const likeCount = reactions[post.id] || 0
+        const hasLiked = userReactions.has(post.id)
+        const hasReposted = userReposts.has(post.id)
+        const isZapping = zapAnimating === post.id
+        const isLiking = likeAnimating === post.id
+
+        return (
+          <div
+            key={post._repostId || post.id}
+            className="animate-fadeIn"
+            style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}
+          >
+            <PostItem
+              post={post}
+              profile={profile}
+              profiles={profiles}
+              likeCount={likeCount}
+              hasLiked={hasLiked}
+              hasReposted={hasReposted}
+              myReactionId={userReactionIds[post.id] || null}
+              myRepostId={userRepostIds[post.id] || null}
+              isLiking={isLiking}
+              isZapping={isZapping}
+              onLike={onLike}
+              onUnlike={onUnlike}
+              onRepost={onRepost}
+              onUnrepost={onUnrepost}
+              onZap={onZap}
+              onZapLongPress={onZapLongPress}
+              onZapLongPressEnd={onZapLongPressEnd}
+              onAvatarClick={onAvatarClick}
+              onHashtagClick={onHashtagClick}
+              onMute={onMute}
+              onDelete={onDelete}
+              onReport={onReport}
+              onBirdwatch={onBirdwatch}
+              onBirdwatchRate={onBirdwatchRate}
+              onNotInterested={onNotInterested}
+              birdwatchNotes={birdwatchLabels[post.id] || []}
+              myPubkey={pubkey}
+              isOwnPost={post.pubkey === pubkey}
+              isRepost={post._isRepost}
+              repostedBy={post._repostedBy ? profiles[post._repostedBy] || { pubkey: post._repostedBy } : null}
+              showNotInterested={showNotInterested}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/ui/components/timeline/TimelineLoading.tsx
+++ b/src/ui/components/timeline/TimelineLoading.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+interface TimelineLoadingProps {
+  count?: number
+  message?: string
+}
+
+export default function TimelineLoading({ count = 5, message = '読み込んでいます...' }: TimelineLoadingProps) {
+  return (
+    <div className="divide-y divide-[var(--border-color)] animate-fadeIn">
+      {Array.from({ length: count }, (_, i) => i + 1).map((i) => (
+        <div key={i} className="skeleton-post" style={{ animationDelay: `${i * 50}ms` }}>
+          <div className="skeleton-avatar skeleton-friendly" />
+          <div className="skeleton-content">
+            <div className="skeleton-line skeleton-line-short skeleton-friendly" />
+            <div className="skeleton-line skeleton-line-full skeleton-friendly" />
+            <div className="skeleton-line skeleton-line-medium skeleton-friendly" />
+          </div>
+        </div>
+      ))}
+      {/* Encouraging message */}
+      <div className="loading-friendly py-4">
+        <div className="loading-dots">
+          <div className="loading-dot" />
+          <div className="loading-dot" />
+          <div className="loading-dot" />
+        </div>
+        <p className="loading-text">{message}</p>
+      </div>
+    </div>
+  )
+}
+
+// Compact loading for "load more" scenarios
+export function TimelineLoadingMore({ message = 'もっと読み込んでいます...' }: { message?: string }) {
+  return (
+    <div className="loading-friendly py-4">
+      <div className="loading-dots">
+        <div className="loading-dot" />
+        <div className="loading-dot" />
+        <div className="loading-dot" />
+      </div>
+      <p className="loading-text">{message}</p>
+    </div>
+  )
+}

--- a/src/ui/components/timeline/index.ts
+++ b/src/ui/components/timeline/index.ts
@@ -3,3 +3,6 @@
  */
 
 export { TimelineHeader, ColumnHeader } from './TimelineHeader'
+export { default as TimelineList } from './TimelineList'
+export { default as TimelineLoading, TimelineLoadingMore } from './TimelineLoading'
+export { default as TimelineEmpty, TimelineEmptyDesktop, TimelineEmptyGlobal } from './TimelineEmpty'


### PR DESCRIPTION
Phase 3 の残りのコンポーネント分割を完了:
- MuteSection: ミュートリスト管理
- RelaySection: リレー設定
- UploadSection: アップロードサーバー設定
- NosskeySettings: パスキー設定
- MiniAppsSection: ミニアプリ管理
- TimelineList: タイムライン投稿リスト
- TimelineLoading: ローディング状態
- TimelineEmpty: 空の状態

CLAUDE.md を更新:
- Phase 1-5 実装完了状況を追加
- Phase 6 React Native 移行プランを追加
- 再利用可能なコード構造を文書化
- 移行タイムラインとリスク対策を記載

https://claude.ai/code/session_012x6vHoo1TtT6ZBo3BC1Rzz