### PR TITLE
fix: 3点メニューのドロップダウンが他の投稿に隠れる問題を修正

### DIFF
--- a/components/LongFormPostItem.js
+++ b/components/LongFormPostItem.js
@@ -293,7 +293,7 @@ export default function LongFormPostItem({
 
   return (
     <>
-      <article className="px-4 py-3 lg:px-5 lg:py-4 relative transition-colors hover:bg-[var(--bg-secondary)]/30">
+      <article className={`px-4 py-3 lg:px-5 lg:py-4 relative transition-colors hover:bg-[var(--bg-secondary)]/30 ${showMenu ? 'z-50' : ''}`}>
         {/* Repost indicator */}
         {isRepost && repostedBy && (
           <div className="flex items-center gap-2 mb-2 text-[var(--text-tertiary)] text-xs">

--- a/components/PostItem.js
+++ b/components/PostItem.js
@@ -708,7 +708,7 @@ export default function PostItem({
   }
 
   return (
-    <article className="px-4 py-3 lg:px-5 lg:py-4 relative transition-colors hover:bg-[var(--bg-secondary)]/30">
+    <article className={`px-4 py-3 lg:px-5 lg:py-4 relative transition-colors hover:bg-[var(--bg-secondary)]/30 ${showMenu ? 'z-50' : ''}`}>
       {/* Repost indicator */}
       {isRepost && repostedBy && (
         <div className="flex items-center gap-2 mb-2 text-[var(--text-tertiary)] text-xs">


### PR DESCRIPTION
メニュー表示中にarticle要素にz-50を付与し、
ドロップダウンのスタッキングコンテキストを隣接する投稿より上に配置。

https://claude.ai/code/session_019HcqPXrYTFtMewbTHoszQA