### PR TITLE
fix: 3点メニューのドロップダウンをcreatePortalでbodyに直接レンダリング

### DIFF
--- a/components/LongFormPostItem.js
+++ b/components/LongFormPostItem.js
@@ -396,7 +396,7 @@ export default function LongFormPostItem({
                   </svg>
                 </button>
 
-                {showMenu && (
+                {showMenu && createPortal(
                   <>
                     <div
                       className="fixed inset-0 z-[60]"
@@ -462,7 +462,8 @@ export default function LongFormPostItem({
                         </button>
                       )}
                     </div>
-                  </>
+                  </>,
+                  document.body
                 )}
               </div>
             </div>

--- a/components/PostItem.js
+++ b/components/PostItem.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import {
   shortenPubkey,
   formatTimestamp,
@@ -821,8 +822,8 @@ export default function PostItem({
                 </svg>
               </button>
 
-              {/* Dropdown menu */}
-              {showMenu && (
+              {/* Dropdown menu - rendered via portal to escape stacking contexts */}
+              {showMenu && createPortal(
                 <>
                   <div
                     className="fixed inset-0 z-[60]"
@@ -899,7 +900,8 @@ export default function PostItem({
                       </button>
                     )}
                   </div>
-                </>
+                </>,
+                document.body
               )}
             </div>
           </div>

--- a/components/UserProfileView.js
+++ b/components/UserProfileView.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { nip19 } from 'nostr-tools'
 import {
   fetchEvents,
@@ -633,8 +634,8 @@ export default function UserProfileView({
                   </svg>
                 </button>
 
-                {/* Dropdown menu */}
-                {showMenu && (
+                {/* Dropdown menu - rendered via portal to escape stacking contexts */}
+                {showMenu && createPortal(
                   <>
                     <div
                       className="fixed inset-0 z-[60]"
@@ -656,7 +657,8 @@ export default function UserProfileView({
                         {muting ? 'ミュート中...' : 'ミュート'}
                       </button>
                     </div>
-                  </>
+                  </>,
+                  document.body
                 )}
               </div>
           )}


### PR DESCRIPTION
position:fixedでも親要素のスタッキングコンテキスト内に閉じ込められ、
下の投稿に被ると表示が崩れる問題を修正。
createPortalでdocument.bodyに直接レンダリングすることで、
すべてのスタッキングコンテキストから脱出し、
常に最前面に表示されるようにした。

対象: PostItem, LongFormPostItem, UserProfileView

https://claude.ai/code/session_019HcqPXrYTFtMewbTHoszQA