### PR TITLE
feat: implement feed API and ingest endpoint (Step 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@
 null--nostr/
 ├── app/                    # Next.js App Router ページ
 │   └── api/
+│       ├── feed/           # フィード API (Rust ランキング) ← Step 2
+│       ├── ingest/         # イベント蓄積 API ← Step 2
 │       ├── nip05/          # NIP-05 検証 API
-│       └── rust-status/    # Rust エンジン状態確認 API ← 新規追加
+│       └── rust-status/    # Rust エンジン状態確認 API
 ├── components/             # React コンポーネント
 ├── lib/                    # JS ビジネスロジック（移行元）
 │   ├── nostr.js            # イベント署名・発行・購読
@@ -35,7 +37,8 @@ null--nostr/
 │   ├── recommendation.js   # フィードランキング (X風アルゴリズム)
 │   ├── filters.js          # Nostr Filter ファクトリ
 │   ├── connection-manager.js # リレー接続管理
-│   └── rust-bridge.js      # Rust ↔ JS ブリッジ ← 新規追加
+│   ├── rust-bridge.js      # Rust ↔ JS ブリッジ
+│   └── rust-engine-manager.js # エンジンシングルトン管理 ← Step 2
 ├── instrumentation.js      # サーバー起動時エンジンロード ← 新規追加
 ├── next.config.js          # instrumentationHook 有効化済み
 └── rust-engine/            # Rust コアエンジン（移行先）
@@ -84,27 +87,41 @@ null--nostr/
 {"rustEngine":{"available":true,"exports":["NuruNuruNapi"]},"runtime":"nodejs"}
 ```
 
-### 未実装・次のステップ 🔲
-
-**Step 2: フィード API の実装（最優先）**
-
-`GET /api/feed` を新規作成し、Rust の `get_recommended_feed()` を使う。
-`TimelineTab.js` はこの API を fetch するように変更する。
+### Step 2: フィード API ✅ 実装済み
 
 アーキテクチャ：
 ```
 ブラウザ (TimelineTab.js)
   ├─ WebSocket → リレー   (イベント受信・投稿はそのまま維持)
   │      ↓ 受信したイベントを
-  └─ POST /api/ingest    → Rust → nostrdb に保存
+  └─ POST /api/ingest    → Rust → nostrdb に保存（バッファリング中）
 
   └─ GET /api/feed       → Rust → nostrdb からランキング済みフィード返却
 ```
 
-実装すべきファイル：
-- `app/api/feed/route.js` — フィード取得 API（Rust `get_recommended_feed` を呼ぶ）
-- `app/api/ingest/route.js` — イベント蓄積 API（Rust `query_local` 経由で nostrdb へ）
-- `components/TimelineTab.js` の修正（`/api/feed` を fetch するよう切り替え）
+実装済みファイル：
+- `lib/rust-engine-manager.js` — エンジンシングルトン管理
+  - サーバーサイドキーで自動初期化（ユーザーの秘密鍵は不要）
+  - `getOrCreateEngine()` / `loginUser(pubkey)` で利用
+- `app/api/feed/route.js` — フィード取得 API
+  - `GET /api/feed?pubkey=xxx&limit=50`
+  - Rust `getRecommendedFeed` → `queryLocal` で完全イベント返却
+  - エンジン未起動時は `{ posts: [], source: 'fallback' }` を返す
+- `app/api/ingest/route.js` — イベント蓄積 API
+  - `POST /api/ingest` with `{ events: [...] }`
+  - NIP-01 バリデーション + サーバーサイドバッファ（最大500件）
+  - nostrdb 直接書き込みは `store_event` napi メソッド追加後に対応
+- `components/TimelineTab.js` の修正
+  - `loadTimelineFull()` と `loadTimeline()` で `/api/feed` を最初に試行
+  - Rust フィード成功時: ランキング済みポストを使用
+  - 失敗時: 既存 JS アルゴリズムにフォールバック（変更なし）
+
+### 未実装・次のステップ 🔲
+
+**Step 2.5: nostrdb 直接書き込み（ingest 完全化）**
+
+`nurunuru-napi` に `store_event(event_json)` メソッドを追加し、
+`/api/ingest` からブラウザ受信イベントを直接 nostrdb に保存する。
 
 **Step 3: プロフィールキャッシュ移行**
 
@@ -143,22 +160,32 @@ npm run dev
 - **WebSocket はブラウザで維持**: リアルタイム購読は既存 JS のまま。
   Rust は「処理・キャッシュ・ランキング」に専念させる。
 
-## `rust-bridge.js` の使い方（API ルート内）
+## エンジンの使い方（API ルート内）
+
+### 低レベル: `rust-bridge.js` (モジュールロード)
 
 ```js
-// app/api/feed/route.js の例
 import { getEngine } from '@/lib/rust-bridge'
+const mod = getEngine() // { NuruNuruNapi } or null
+```
+
+### 推奨: `rust-engine-manager.js` (シングルトン管理)
+
+```js
+// app/api/feed/route.js で実際に使用中
+import { getOrCreateEngine, loginUser } from '@/lib/rust-engine-manager'
 
 export async function GET(req) {
-  const engine = getEngine()
+  const pubkey = new URL(req.url).searchParams.get('pubkey')
+  const engine = await loginUser(pubkey) // 自動初期化 + リレー接続 + ログイン
   if (!engine) {
-    // フォールバック: JS 実装を呼ぶ
-    return Response.json({ error: 'Rust engine not available' }, { status: 503 })
+    return Response.json({ posts: [], source: 'fallback' })
   }
-  // NuruNuruNapi インスタンスを作成して使う
-  const client = await engine.NuruNuruNapi.create(secretKeyHex, './nurunuru-db')
-  const feed = await client.getRecommendedFeed(50)
-  return Response.json(feed)
+  const scored = await engine.getRecommendedFeed(50)
+  // queryLocal でフルイベント取得
+  const filter = JSON.stringify({ ids: scored.map(s => s.eventId) })
+  const events = (await engine.queryLocal(filter)).map(j => JSON.parse(j))
+  return Response.json({ posts: events, source: 'rust' })
 }
 ```
 
@@ -174,5 +201,5 @@ wss://search.nos.today     (NIP-50 検索専用)
 
 ## ブランチ運用
 
-- 作業ブランチ: `claude/create-napi-rs-bridge-7SBPn`
+- 作業ブランチ: `claude/continue-from-claude-md-mdAJa`
 - マージ先: `master`

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -1,0 +1,95 @@
+/**
+ * GET /api/feed
+ *
+ * Returns a ranked feed using the Rust recommendation engine.
+ * Falls back to an empty response if the engine is unavailable
+ * (client uses its own JS algorithm as fallback).
+ *
+ * Query params:
+ *   pubkey - User's public key hex (required for personalized feed)
+ *   limit  - Maximum number of posts (default: 50, max: 200)
+ */
+
+import { getOrCreateEngine, loginUser } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url)
+  const pubkey = searchParams.get('pubkey')
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10) || 50, 200)
+
+  if (!pubkey) {
+    return Response.json(
+      { error: 'pubkey parameter is required' },
+      { status: 400 }
+    )
+  }
+
+  // Validate pubkey format (64-char hex)
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+    return Response.json(
+      { error: 'Invalid pubkey format' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const engine = await loginUser(pubkey)
+    if (!engine) {
+      return Response.json({ posts: [], source: 'fallback', reason: 'engine_unavailable' })
+    }
+
+    // Step 1: Get scored posts from recommendation engine
+    const scored = await engine.getRecommendedFeed(limit)
+
+    if (!scored || scored.length === 0) {
+      return Response.json({ posts: [], source: 'rust', reason: 'no_scored_posts' })
+    }
+
+    // Step 2: Fetch full events from nostrdb by their IDs
+    const eventIds = scored.map(s => s.eventId)
+    const filterJson = JSON.stringify({ ids: eventIds })
+    let events = []
+
+    try {
+      const eventJsons = await engine.queryLocal(filterJson)
+      events = eventJsons.map(j => JSON.parse(j))
+    } catch (e) {
+      console.warn('[api/feed] queryLocal failed, returning scores only:', e.message)
+    }
+
+    // Step 3: Build score lookup and merge with events
+    const scoreMap = new Map()
+    for (const s of scored) {
+      scoreMap.set(s.eventId, { score: s.score, createdAt: s.createdAt })
+    }
+
+    if (events.length > 0) {
+      // Full mode: events with scores
+      const feed = events.map(e => ({
+        ...e,
+        _score: scoreMap.get(e.id)?.score || 0,
+      }))
+
+      // Sort by score (descending)
+      feed.sort((a, b) => (b._score || 0) - (a._score || 0))
+
+      return Response.json({ posts: feed, source: 'rust' })
+    }
+
+    // Scores-only mode: return scored post metadata (client can match with local events)
+    return Response.json({
+      scores: scored.map(s => ({
+        eventId: s.eventId,
+        pubkey: s.pubkey,
+        score: s.score,
+        createdAt: s.createdAt,
+      })),
+      source: 'rust_scores_only',
+    })
+  } catch (e) {
+    console.error('[api/feed] Error:', e.message)
+    return Response.json({ posts: [], source: 'fallback', error: e.message })
+  }
+}

--- a/app/api/ingest/route.js
+++ b/app/api/ingest/route.js
@@ -1,0 +1,121 @@
+/**
+ * POST /api/ingest
+ *
+ * Receives Nostr events from the browser and stores them for the
+ * Rust engine to use in feed ranking.
+ *
+ * The browser maintains WebSocket connections to relays and receives
+ * events in real-time. This endpoint lets the browser push those events
+ * to the server-side nostrdb for the recommendation engine.
+ *
+ * Body (JSON):
+ *   events - Array of Nostr event objects (NIP-01 format)
+ *
+ * Currently the engine receives events from relays directly.
+ * This endpoint validates and acknowledges events; full nostrdb
+ * storage will be added when a store_event napi method is available.
+ */
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+// Server-side event buffer for events not yet in nostrdb.
+// Kept small (LRU-style) to avoid memory issues.
+const EVENT_BUFFER_MAX = 500
+const eventBuffer = new Map()
+
+/**
+ * Validate a Nostr event has required fields (NIP-01).
+ */
+function isValidEvent(event) {
+  return (
+    event &&
+    typeof event.id === 'string' && /^[0-9a-f]{64}$/.test(event.id) &&
+    typeof event.pubkey === 'string' && /^[0-9a-f]{64}$/.test(event.pubkey) &&
+    typeof event.created_at === 'number' &&
+    typeof event.kind === 'number' &&
+    Array.isArray(event.tags) &&
+    typeof event.content === 'string' &&
+    typeof event.sig === 'string'
+  )
+}
+
+export async function POST(req) {
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { events } = body
+
+  if (!Array.isArray(events)) {
+    return Response.json(
+      { error: 'events must be an array of Nostr events' },
+      { status: 400 }
+    )
+  }
+
+  if (events.length > 100) {
+    return Response.json(
+      { error: 'Maximum 100 events per request' },
+      { status: 400 }
+    )
+  }
+
+  // Validate and buffer events
+  let accepted = 0
+  let duplicate = 0
+  let invalid = 0
+
+  for (const event of events) {
+    if (!isValidEvent(event)) {
+      invalid++
+      continue
+    }
+
+    if (eventBuffer.has(event.id)) {
+      duplicate++
+      continue
+    }
+
+    // Add to buffer (evict oldest if full)
+    if (eventBuffer.size >= EVENT_BUFFER_MAX) {
+      const oldestKey = eventBuffer.keys().next().value
+      eventBuffer.delete(oldestKey)
+    }
+    eventBuffer.set(event.id, event)
+    accepted++
+  }
+
+  // If engine is available, try to use queryLocal to verify storage
+  // (future: direct nostrdb write when napi method is available)
+  const engine = await getOrCreateEngine()
+  const engineAvailable = !!engine
+
+  return Response.json({
+    accepted,
+    duplicate,
+    invalid,
+    total: events.length,
+    buffered: eventBuffer.size,
+    engineAvailable,
+  })
+}
+
+/**
+ * GET /api/ingest
+ *
+ * Returns buffer stats (for debugging).
+ */
+export async function GET() {
+  const engine = await getOrCreateEngine()
+
+  return Response.json({
+    buffered: eventBuffer.size,
+    maxBuffer: EVENT_BUFFER_MAX,
+    engineAvailable: !!engine,
+  })
+}

--- a/lib/rust-engine-manager.js
+++ b/lib/rust-engine-manager.js
@@ -1,0 +1,102 @@
+/**
+ * Rust engine singleton manager (server-side only).
+ *
+ * Manages a single NuruNuruNapi instance that is created once,
+ * connected to relays, and reused across API requests.
+ *
+ * The engine uses a server-side key (not the user's key) for
+ * relay connections. Publishing still happens from the browser.
+ */
+
+const { getEngine } = require('./rust-bridge')
+
+let instance = null
+let initPromise = null
+let currentLoginPubkey = null
+
+/**
+ * Generate a random 32-byte hex string for server engine initialization.
+ * This key is only used for relay connections, not for signing user events.
+ */
+function generateServerKey() {
+  const crypto = require('node:crypto')
+  return crypto.randomBytes(32).toString('hex')
+}
+
+/**
+ * Get or create the singleton engine instance.
+ * First call initializes the engine and connects to relays.
+ * Subsequent calls return the cached instance immediately.
+ *
+ * @returns {Promise<object|null>} NuruNuruNapi instance, or null if unavailable
+ */
+async function getOrCreateEngine() {
+  if (instance) return instance
+
+  // Prevent concurrent initialization
+  if (initPromise) return initPromise
+
+  initPromise = (async () => {
+    const mod = getEngine()
+    if (!mod) {
+      console.log('[engine-manager] Rust engine not available')
+      initPromise = null
+      return null
+    }
+
+    try {
+      const serverKey = process.env.NURUNURU_SERVER_KEY || generateServerKey()
+      const dbPath = process.env.NURUNURU_DB_PATH || './nurunuru-db'
+
+      console.log('[engine-manager] Creating engine instance...')
+      instance = await mod.NuruNuruNapi.create(serverKey, dbPath)
+
+      console.log('[engine-manager] Connecting to relays...')
+      await instance.connect()
+
+      console.log('[engine-manager] Engine ready')
+      return instance
+    } catch (e) {
+      console.error('[engine-manager] Failed to initialize:', e.message)
+      instance = null
+      initPromise = null
+      return null
+    }
+  })()
+
+  return initPromise
+}
+
+/**
+ * Login as a user (loads their follow/mute lists for recommendations).
+ * Only re-logins if the pubkey has changed since last call.
+ *
+ * @param {string} pubkey - User's public key hex
+ * @returns {Promise<object|null>} Engine instance, or null if unavailable
+ */
+async function loginUser(pubkey) {
+  const engine = await getOrCreateEngine()
+  if (!engine) return null
+
+  if (currentLoginPubkey !== pubkey) {
+    try {
+      console.log('[engine-manager] Logging in user:', pubkey.slice(0, 8) + '...')
+      await engine.login(pubkey)
+      currentLoginPubkey = pubkey
+    } catch (e) {
+      console.error('[engine-manager] Login failed:', e.message)
+      // Continue without login — feed will still work, just without personalization
+    }
+  }
+
+  return engine
+}
+
+/**
+ * Get the current login pubkey (if any).
+ */
+function getCurrentLoginPubkey() {
+  return currentLoginPubkey
+}
+
+module.exports = { getOrCreateEngine, loginUser, getCurrentLoginPubkey }


### PR DESCRIPTION
Add server-side feed ranking via Rust engine:
- lib/rust-engine-manager.js: singleton engine with auto-init, relay connect, and user login caching
- app/api/feed/route.js: GET /api/feed?pubkey=xxx returns ranked posts from Rust getRecommendedFeed + queryLocal for full events
- app/api/ingest/route.js: POST /api/ingest receives browser events with NIP-01 validation and server-side buffering
- components/TimelineTab.js: loadTimelineFull and loadTimeline try Rust feed first, fall back to existing JS algorithm if unavailable

https://claude.ai/code/session_01RcTawyRtkC5mPi1Gc5yLSJ