### PR TITLE
feat(step5): イベント発行の API 化 — POST /api/publish 実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ null--nostr/
 │       │   ├── [pubkey]/   # 単一プロフィール取得 API ← Step 3
 │       │   └── batch/      # バッチプロフィール取得 API ← Step 3
 │       ├── nip05/          # NIP-05 検証 API
+│       ├── publish/        # イベント発行 API ← Step 5
 │       ├── relay/          # リレー管理 API ← Step 4
 │       │   └── reconnect/  # 強制再接続 API ← Step 4
 │       └── rust-status/    # Rust エンジン状態確認 API
@@ -346,6 +347,21 @@ await engine.reconnect()
 import { getRelayList, addRelay, removeRelay, reconnectRelays } from '@/lib/rust-engine-manager'
 ```
 
+### publish API (Step 5〜)
+
+```js
+// app/api/publish/route.js で実際に使用中
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+// 署名済みイベントを全リレーにブロードキャスト
+// engine.publishEvent(eventJson) → nostr-sdk が署名検証 → relay pool に送出
+const eventId = await engine.publishEvent(JSON.stringify(signedEvent))
+// → イベント ID の hex 文字列
+
+// lib/nostr.js の publishEvent() から自動呼び出し (透過的)
+// ブラウザ側コードの変更は不要 — Rust broadcast が優先され、失敗時は JS fallback
+```
+
 ## デフォルトリレー（日本）
 
 ```
@@ -358,7 +374,7 @@ wss://search.nos.today     (NIP-50 検索専用)
 
 ## ブランチ運用
 
-- 作業ブランチ: `claude/complete-relay-migration-LTFSb`
+- 作業ブランチ: `claude/complete-event-api-WiHhn`
 - マージ先: `master`
 
 ---
@@ -376,7 +392,7 @@ Step 1〜4 で「Rust エンジンのキャッシュ・ランキング・リレ�
 | イベント永続化 | ✅ Rust (nostrdb 直接書き込み) |
 | プロフィールキャッシュ | ✅ Rust (nostrdb → リレーの2段階) |
 | リレー管理 | ✅ Rust (add/remove/reconnect) |
-| イベント発行 | ❌ JS (publishManaged → connection-manager) |
+| イベント発行 | ✅ Rust (/api/publish → engine.publishEvent) |
 | リアルタイム購読 | ❌ JS (subscribeManaged → nostr-tools SimplePool) |
 | フォロー/ミュートリスト編集 | ❌ JS |
 | DM 暗号化・送信 | ❌ JS |
@@ -396,32 +412,46 @@ Step 1〜4 で「Rust エンジンのキャッシュ・ランキング・リレ�
 
 ## 次フェーズのロードマップ
 
-### Step 5: イベント発行の API 化 🔲
+### Step 5: イベント発行の API 化 ✅ 実装済み
 
-**目標**: ブラウザで署名した済みイベントを Rust エンジン経由でリレーに送る。
-`publishManaged()` を `POST /api/publish` に置き換えることで
-`connection-manager.js` の publish 依存を排除する。
-
+アーキテクチャ：
 ```
 ブラウザ (NIP-07 / Amber / NIP-46)
   └─ signEvent(event) → signedEvent
         ↓
   POST /api/publish { event: signedEvent }
         ↓
-  Rust engine.client.send_event(event)
+  engine.publishEvent(eventJson) → client.send_event(&event)
         ↓
   接続中の全リレーに broadcast
+        ↓
+  { id, relays: ['wss://...'], source: 'rust' }
 ```
 
-実装予定ファイル：
+実装済みファイル：
 - `nurunuru-core/src/engine.rs` — `publish_raw_event(event: Event) -> Result<EventId>`
-  - `client.send_event(event)` — 検証済みイベントをそのまま送出
+  - `client.send_event(&event)` — 署名済みイベントをそのまま送出
+  - nostr-sdk が署名を自動検証してから broadcast
 - `nurunuru-napi/src/lib.rs` — `publishEvent(eventJson: String) -> Result<String>`
+  - `Event::from_json()` でデシリアライズ → `publish_raw_event()` 呼び出し
+  - 成功時: イベント ID の hex 文字列を返す
 - `app/api/publish/route.js` — `POST /api/publish { event }` エンドポイント
-  - NIP-01 署名検証 (Rust 側で自動) → broadcast
+  - NIP-01 フィールドバリデーション (id/pubkey/sig の形式チェック)
+  - Rust 側でも署名検証 → 全リレーに broadcast
   - レスポンス: `{ id, relays: ['wss://...'], source: 'rust' }`
+  - エンジン未起動時: `503 { error, source: 'unavailable' }`
 - `lib/nostr.js` の `publishEvent()` を修正
-  - Rust API 試行 → 失敗時 JS フォールバック維持
+  - まず `/api/publish` を試行 (Rust broadcast)
+  - 失敗時: 既存 `publishManaged()` JS フォールバック維持
+
+`POST /api/publish` レスポンス例：
+```json
+{
+  "id": "a1b2c3...64hex...",
+  "relays": ["wss://yabu.me", "wss://relay-jp.nostr.wirednet.jp"],
+  "source": "rust"
+}
+```
 
 ### Step 6: フォロー/ミュートリスト管理の API 化 🔲
 

--- a/app/api/publish/route.js
+++ b/app/api/publish/route.js
@@ -1,0 +1,92 @@
+/**
+ * POST /api/publish
+ *
+ * ブラウザで署名済みの Nostr イベントを受け取り、
+ * Rust エンジン経由で接続中の全リレーにブロードキャストする。
+ *
+ * フロー:
+ *   ブラウザ (NIP-07 / Amber / NIP-46 で署名)
+ *     └─ POST /api/publish { event: signedEvent }
+ *           └─ engine.publishEvent(eventJson) → client.send_event() → 全リレー
+ *
+ * Body (JSON):
+ *   event - 署名済み Nostr イベント (NIP-01 フォーマット)
+ *
+ * Response:
+ *   { id, relays, source: 'rust' }
+ *   エラー時: { error, source: 'error' | 'unavailable' }
+ */
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+/**
+ * NIP-01 必須フィールドの簡易バリデーション
+ */
+function isValidEvent(event) {
+  return (
+    event &&
+    typeof event.id === 'string' && /^[0-9a-f]{64}$/.test(event.id) &&
+    typeof event.pubkey === 'string' && /^[0-9a-f]{64}$/.test(event.pubkey) &&
+    typeof event.created_at === 'number' &&
+    typeof event.kind === 'number' &&
+    Array.isArray(event.tags) &&
+    typeof event.content === 'string' &&
+    typeof event.sig === 'string' && event.sig.length === 128
+  )
+}
+
+export async function POST(req) {
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { event } = body
+
+  if (!isValidEvent(event)) {
+    return Response.json(
+      { error: 'Invalid event: missing or malformed NIP-01 fields' },
+      { status: 400 }
+    )
+  }
+
+  const engine = await getOrCreateEngine()
+
+  if (!engine) {
+    // Rust エンジン未起動: フォールバック指示を返す
+    return Response.json(
+      { error: 'Rust engine unavailable', source: 'unavailable' },
+      { status: 503 }
+    )
+  }
+
+  try {
+    const eventId = await engine.publishEvent(JSON.stringify(event))
+
+    // 接続中リレー一覧を返す (クライアントへの情報提供)
+    let relays = []
+    try {
+      const relayList = await engine.getRelayList()
+      relays = relayList.filter(r => r.connected).map(r => r.url)
+    } catch {
+      // リレー一覧取得失敗は無視
+    }
+
+    return Response.json({
+      id: eventId,
+      relays,
+      source: 'rust',
+    })
+  } catch (err) {
+    console.error('[api/publish] Failed to publish event:', err.message)
+    return Response.json(
+      { error: err.message || 'Failed to publish event', source: 'error' },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -855,10 +855,26 @@ export function subscribeToEvents(filter, relays, onEvent, onEose, onError) {
  * @returns {Promise<boolean>} True if published successfully
  */
 export async function publishEvent(event, relays = [getDefaultRelay()]) {
-  // Filter out invalid relay URLs
-  const validRelays = filterValidRelays(relays)
+  // Step 5: Rust エンジン経由での発行を最初に試みる
+  // ブラウザが署名したイベントをサーバーサイドの Rust relay pool で broadcast
+  try {
+    const res = await fetch('/api/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event }),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      if (data.id) {
+        return true
+      }
+    }
+  } catch {
+    // ネットワークエラー等は無視して JS フォールバックへ
+  }
 
-  // Use connection manager for publishing with automatic retry
+  // JS フォールバック: connection-manager 経由で発行
+  const validRelays = filterValidRelays(relays)
   try {
     await publishManaged(event, validRelays)
     return true

--- a/rust-engine/nurunuru-core/src/engine.rs
+++ b/rust-engine/nurunuru-core/src/engine.rs
@@ -804,6 +804,19 @@ impl NuruNuruEngine {
         Ok(events.into_iter().collect())
     }
 
+    /// Publish an already-signed Nostr event to all connected relays.
+    ///
+    /// Unlike `publish_note` which builds and signs an event, this method
+    /// takes a fully-signed event from the browser (signed via NIP-07 / Amber
+    /// / NIP-46) and broadcasts it as-is. The nostr-sdk client verifies the
+    /// signature before sending.
+    ///
+    /// Returns the event ID on success.
+    pub async fn publish_raw_event(&self, event: Event) -> Result<EventId> {
+        let output = self.client.send_event(&event).await?;
+        Ok(output.val)
+    }
+
     /// Store a raw event directly into nostrdb (bypasses relay network).
     ///
     /// Used by `/api/ingest` to persist browser-received events so they are

--- a/rust-engine/nurunuru-napi/src/lib.rs
+++ b/rust-engine/nurunuru-napi/src/lib.rs
@@ -348,6 +348,23 @@ impl NuruNuruNapi {
         Ok(result.to_hex())
     }
 
+    /// Publish an already-signed Nostr event to all connected relays.
+    ///
+    /// `event_json` — full NIP-01 signed event as a JSON string (must include `sig`).
+    ///
+    /// The Rust engine validates the signature before broadcasting.
+    /// Returns the event ID hex on success.
+    ///
+    /// Called from `/api/publish` to broadcast browser-signed events via the
+    /// Rust relay pool without exposing the user's private key to the server.
+    #[napi]
+    pub async fn publish_event(&self, event_json: String) -> Result<String> {
+        let event: Event = Event::from_json(&event_json).map_err(to_napi_err)?;
+        let engine = self.engine.clone();
+        let eid = engine.publish_raw_event(event).await.map_err(to_napi_err)?;
+        Ok(eid.to_hex())
+    }
+
     // ─── DMs (NIP-17) ─────────────────────────────────────────
 
     /// Send an encrypted DM via NIP-17 gift wrapping.


### PR DESCRIPTION
ブラウザで署名済みの Nostr イベントを Rust エンジン経由で
全リレーにブロードキャストする /api/publish エンドポイントを実装。
lib/nostr.js の publishEvent() が Rust broadcast を優先し、 失敗時は既存の JS (publishManaged) にフォールバックする。

変更ファイル:
- nurunuru-core/src/engine.rs: publish_raw_event() 追加 client.send_event(&event) で署名済みイベントを relay pool に送出
- nurunuru-napi/src/lib.rs: publishEvent(eventJson) NAPI バインディング追加
- app/api/publish/route.js: POST /api/publish エンドポイント新規作成 NIP-01 バリデーション → engine.publishEvent() → { id, relays, source }
- lib/nostr.js: publishEvent() を Rust API 優先 + JS フォールバック構成に変更
- CLAUDE.md: Step 5 完了状態に更新

https://claude.ai/code/session_014yBewPmFsPiSmB8c7GXgG8