### PR TITLE
Step 6: フォロー/ミュートリスト管理の API 化

### DIFF
--- a/app/api/social/follows/route.js
+++ b/app/api/social/follows/route.js
@@ -1,0 +1,128 @@
+/**
+ * GET /api/social/follows?pubkey=xxx
+ *
+ * Fetches a Nostr follow list (kind 3, NIP-02) using the Rust engine.
+ *
+ * Strategy:
+ *   1. Query nostrdb local cache first (fast, no relay round-trip)
+ *   2. If not found, fetch from relay via Rust engine
+ *   3. If engine unavailable, return { follows: [], source: 'fallback' }
+ *
+ * Response:
+ *   { follows: string[], source: 'nostrdb' | 'rust' | 'fallback' }
+ *
+ * POST /api/social/follows
+ *
+ * Updates the follow list by publishing a signed kind 3 event.
+ * The browser is responsible for signing the event (NIP-07 / Amber / NIP-46).
+ * This endpoint delegates publishing to /api/publish.
+ *
+ * Request body:
+ *   { event: SignedNostrEvent }   — pre-signed kind 3 event
+ *
+ * Response:
+ *   { id: string, relays: string[], source: string }
+ */
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Parse a kind-3 contact list event into an array of followed pubkeys.
+ * Mirrors the JS fetchFollowList() logic.
+ */
+function parseFollowsFromEvent(eventJson) {
+  try {
+    const event = typeof eventJson === 'string' ? JSON.parse(eventJson) : eventJson
+    if (event.kind !== 3) return null
+    return event.tags
+      .filter(tag => tag[0] === 'p' && tag[1])
+      .map(tag => tag[1])
+  } catch {
+    return null
+  }
+}
+
+export async function GET(req) {
+  const pubkey = new URL(req.url).searchParams.get('pubkey')
+
+  if (!pubkey || !/^[0-9a-f]{64}$/.test(pubkey)) {
+    return Response.json({ error: 'Invalid pubkey' }, { status: 400 })
+  }
+
+  const engine = await getOrCreateEngine()
+
+  if (!engine) {
+    return Response.json({ follows: [], source: 'fallback' })
+  }
+
+  // ── Step 1: Query nostrdb local cache (instant, no relay) ──────
+  try {
+    const localFilter = JSON.stringify({ kinds: [3], authors: [pubkey], limit: 1 })
+    const localEvents = await engine.queryLocal(localFilter)
+
+    if (localEvents && localEvents.length > 0) {
+      const follows = parseFollowsFromEvent(localEvents[0])
+      if (follows !== null) {
+        return Response.json({ follows, source: 'nostrdb' })
+      }
+    }
+  } catch (err) {
+    console.warn('[api/social/follows] queryLocal failed:', err.message)
+  }
+
+  // ── Step 2: Fetch from relay via Rust engine ───────────────────
+  try {
+    const follows = await engine.fetchFollowList(pubkey)
+    return Response.json({ follows, source: 'rust' })
+  } catch (err) {
+    console.warn('[api/social/follows] fetchFollowList failed:', err.message)
+    return Response.json({ follows: [], source: 'fallback' })
+  }
+}
+
+export async function POST(req) {
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { event } = body
+
+  if (!event) {
+    return Response.json({ error: 'Missing event' }, { status: 400 })
+  }
+
+  // Validate this is a kind 3 (contact list) event
+  if (event.kind !== 3) {
+    return Response.json({ error: 'Event must be kind 3 (contact list)' }, { status: 400 })
+  }
+
+  // Validate required NIP-01 fields
+  if (!event.id || !event.pubkey || !event.sig) {
+    return Response.json({ error: 'Missing required fields: id, pubkey, sig' }, { status: 400 })
+  }
+
+  // Delegate to /api/publish for signing validation and relay broadcast
+  try {
+    const publishRes = await fetch(new URL('/api/publish', req.url).toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event }),
+    })
+
+    const result = await publishRes.json()
+
+    if (!publishRes.ok) {
+      return Response.json(result, { status: publishRes.status })
+    }
+
+    return Response.json(result)
+  } catch (err) {
+    console.error('[api/social/follows] publish delegation failed:', err.message)
+    return Response.json({ error: 'Failed to publish event' }, { status: 500 })
+  }
+}

--- a/app/api/social/mutes/route.js
+++ b/app/api/social/mutes/route.js
@@ -1,0 +1,148 @@
+/**
+ * GET /api/social/mutes?pubkey=xxx
+ *
+ * Fetches a Nostr mute list (kind 10000, NIP-51) using the Rust engine.
+ *
+ * Strategy:
+ *   1. Query nostrdb local cache first (fast, full tag structure)
+ *   2. If not found, fetch from relay via Rust engine (pubkeys only)
+ *   3. If engine unavailable, return { mutes: empty, source: 'fallback' }
+ *
+ * Response:
+ *   {
+ *     mutes: { pubkeys: string[], eventIds: string[], hashtags: string[], words: string[] },
+ *     source: 'nostrdb' | 'rust' | 'fallback'
+ *   }
+ *
+ * POST /api/social/mutes
+ *
+ * Updates the mute list by publishing a signed kind 10000 event.
+ * The browser is responsible for signing the event (NIP-07 / Amber / NIP-46).
+ * This endpoint delegates publishing to /api/publish.
+ *
+ * Request body:
+ *   { event: SignedNostrEvent }   — pre-signed kind 10000 event
+ *
+ * Response:
+ *   { id: string, relays: string[], source: string }
+ */
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+const EMPTY_MUTES = { pubkeys: [], eventIds: [], hashtags: [], words: [] }
+
+/**
+ * Parse a kind-10000 mute list event into the full mute structure.
+ * Mirrors the JS fetchMuteList() logic, supporting all tag types:
+ *   p  → muted pubkeys
+ *   e  → muted event IDs
+ *   t  → muted hashtags
+ *   word → muted words
+ */
+function parseMutesFromEvent(eventJson) {
+  try {
+    const event = typeof eventJson === 'string' ? JSON.parse(eventJson) : eventJson
+    if (event.kind !== 10000) return null
+
+    const pubkeys = event.tags.filter(t => t[0] === 'p' && t[1]).map(t => t[1])
+    const eventIds = event.tags.filter(t => t[0] === 'e' && t[1]).map(t => t[1])
+    const hashtags = event.tags.filter(t => t[0] === 't' && t[1]).map(t => t[1])
+    const words = event.tags.filter(t => t[0] === 'word' && t[1]).map(t => t[1])
+
+    return { pubkeys, eventIds, hashtags, words }
+  } catch {
+    return null
+  }
+}
+
+export async function GET(req) {
+  const pubkey = new URL(req.url).searchParams.get('pubkey')
+
+  if (!pubkey || !/^[0-9a-f]{64}$/.test(pubkey)) {
+    return Response.json({ error: 'Invalid pubkey' }, { status: 400 })
+  }
+
+  const engine = await getOrCreateEngine()
+
+  if (!engine) {
+    return Response.json({ mutes: EMPTY_MUTES, source: 'fallback' })
+  }
+
+  // ── Step 1: Query nostrdb local cache (instant, full tag structure) ──
+  try {
+    const localFilter = JSON.stringify({ kinds: [10000], authors: [pubkey], limit: 1 })
+    const localEvents = await engine.queryLocal(localFilter)
+
+    if (localEvents && localEvents.length > 0) {
+      const mutes = parseMutesFromEvent(localEvents[0])
+      if (mutes !== null) {
+        return Response.json({ mutes, source: 'nostrdb' })
+      }
+    }
+  } catch (err) {
+    console.warn('[api/social/mutes] queryLocal failed:', err.message)
+  }
+
+  // ── Step 2: Fetch from relay via Rust engine (pubkeys only) ───────────
+  // Note: The Rust fetch_mute_list only extracts p-tags (muted pubkeys).
+  // hashtags, eventIds, and words are only available when the full event
+  // is cached in nostrdb (Step 1). The relay fetch populates nostrdb so
+  // future requests will return the full structure via Step 1.
+  try {
+    const mutedPubkeys = await engine.fetchMuteList(pubkey)
+    return Response.json({
+      mutes: { pubkeys: mutedPubkeys, eventIds: [], hashtags: [], words: [] },
+      source: 'rust',
+    })
+  } catch (err) {
+    console.warn('[api/social/mutes] fetchMuteList failed:', err.message)
+    return Response.json({ mutes: EMPTY_MUTES, source: 'fallback' })
+  }
+}
+
+export async function POST(req) {
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { event } = body
+
+  if (!event) {
+    return Response.json({ error: 'Missing event' }, { status: 400 })
+  }
+
+  // Validate this is a kind 10000 (mute list) event
+  if (event.kind !== 10000) {
+    return Response.json({ error: 'Event must be kind 10000 (mute list)' }, { status: 400 })
+  }
+
+  // Validate required NIP-01 fields
+  if (!event.id || !event.pubkey || !event.sig) {
+    return Response.json({ error: 'Missing required fields: id, pubkey, sig' }, { status: 400 })
+  }
+
+  // Delegate to /api/publish for signing validation and relay broadcast
+  try {
+    const publishRes = await fetch(new URL('/api/publish', req.url).toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event }),
+    })
+
+    const result = await publishRes.json()
+
+    if (!publishRes.ok) {
+      return Response.json(result, { status: publishRes.status })
+    }
+
+    return Response.json(result)
+  } catch (err) {
+    console.error('[api/social/mutes] publish delegation failed:', err.message)
+    return Response.json({ error: 'Failed to publish event' }, { status: 500 })
+  }
+}

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -1636,6 +1636,7 @@ export async function uploadImage(file) {
 // ============================================
 
 // Fetch mute list with caching
+// Tries /api/social/mutes (Rust/nostrdb) first, falls back to direct relay fetch
 export async function fetchMuteListCached(pubkey, forceRefresh = false) {
   if (!forceRefresh) {
     const cached = getCachedMuteList(pubkey)
@@ -1643,13 +1644,29 @@ export async function fetchMuteListCached(pubkey, forceRefresh = false) {
       return cached
     }
   }
-  
+
+  // Try Rust engine via API route first
+  try {
+    const res = await fetch(`/api/social/mutes?pubkey=${pubkey}`)
+    if (res.ok) {
+      const data = await res.json()
+      if (data.source !== 'fallback') {
+        const muteList = { ...data.mutes, rawEvent: null }
+        setCachedMuteList(pubkey, muteList)
+        return muteList
+      }
+    }
+  } catch {
+    // API unavailable — fall through to JS implementation
+  }
+
   const muteList = await fetchMuteList(pubkey)
   setCachedMuteList(pubkey, muteList)
   return muteList
 }
 
 // Fetch follow list with caching
+// Tries /api/social/follows (Rust/nostrdb) first, falls back to direct relay fetch
 export async function fetchFollowListCached(pubkey, forceRefresh = false) {
   if (!forceRefresh) {
     const cached = getCachedFollowList(pubkey)
@@ -1657,7 +1674,21 @@ export async function fetchFollowListCached(pubkey, forceRefresh = false) {
       return cached
     }
   }
-  
+
+  // Try Rust engine via API route first
+  try {
+    const res = await fetch(`/api/social/follows?pubkey=${pubkey}`)
+    if (res.ok) {
+      const data = await res.json()
+      if (data.source !== 'fallback') {
+        setCachedFollowList(pubkey, data.follows)
+        return data.follows
+      }
+    }
+  } catch {
+    // API unavailable — fall through to JS implementation
+  }
+
   const followList = await fetchFollowList(pubkey)
   setCachedFollowList(pubkey, followList)
   return followList

--- a/lib/rust-engine-manager.js
+++ b/lib/rust-engine-manager.js
@@ -177,6 +177,51 @@ async function reconnectRelays() {
   }
 }
 
+// ──────────────────────────────────────────────
+// Social list helpers (Step 6: フォロー/ミュートリスト管理)
+// ──────────────────────────────────────────────
+
+/**
+ * Fetch follow list (kind 3, NIP-02) for a pubkey via Rust engine.
+ * Returns an array of followed pubkey hex strings.
+ *
+ * @param {string} pubkey - User's public key hex
+ * @returns {Promise<string[]|null>} Array of followed pubkeys, or null if unavailable
+ */
+async function getFollowList(pubkey) {
+  const engine = await getOrCreateEngine()
+  if (!engine) return null
+
+  try {
+    return await engine.fetchFollowList(pubkey)
+  } catch (e) {
+    console.error('[engine-manager] getFollowList failed:', e.message)
+    return null
+  }
+}
+
+/**
+ * Fetch mute list (kind 10000, NIP-51) for a pubkey via Rust engine.
+ * Returns an array of muted pubkey hex strings (p-tags only).
+ *
+ * Note: For the full mute structure including eventIds, hashtags, and words,
+ * use GET /api/social/mutes which also queries nostrdb for the full event.
+ *
+ * @param {string} pubkey - User's public key hex
+ * @returns {Promise<string[]|null>} Array of muted pubkeys, or null if unavailable
+ */
+async function getMuteList(pubkey) {
+  const engine = await getOrCreateEngine()
+  if (!engine) return null
+
+  try {
+    return await engine.fetchMuteList(pubkey)
+  } catch (e) {
+    console.error('[engine-manager] getMuteList failed:', e.message)
+    return null
+  }
+}
+
 module.exports = {
   getOrCreateEngine,
   loginUser,
@@ -185,4 +230,6 @@ module.exports = {
   addRelay,
   removeRelay,
   reconnectRelays,
+  getFollowList,
+  getMuteList,
 }

--- a/rust-engine/nurunuru-napi/src/lib.rs
+++ b/rust-engine/nurunuru-napi/src/lib.rs
@@ -218,6 +218,18 @@ impl NuruNuruNapi {
         engine.fetch_follow_list(pk).await.map_err(to_napi_err)
     }
 
+    /// Fetch mute list (kind 10000, NIP-51). Returns pubkey hex strings.
+    ///
+    /// Note: Only returns muted pubkeys (`p` tags). For the full mute list
+    /// structure (eventIds, hashtags, words), use `queryLocal` with kind 10000
+    /// to inspect all tag types from the cached event.
+    #[napi]
+    pub async fn fetch_mute_list(&self, pubkey_hex: String) -> Result<Vec<String>> {
+        let pk = PublicKey::from_hex(&pubkey_hex).map_err(to_napi_err)?;
+        let engine = self.engine.clone();
+        engine.fetch_mute_list(pk).await.map_err(to_napi_err)
+    }
+
     /// Follow a user (publishes updated kind 3).
     #[napi]
     pub async fn follow_user(&self, target_pubkey_hex: String) -> Result<()> {


### PR DESCRIPTION
- nurunuru-napi/src/lib.rs: fetchMuteList NAPI バインディング追加 (engine.fetch_mute_list をラップして Vec<String> を返す)
- app/api/social/follows/route.js: フォローリスト取得・更新 API GET: nostrdb → リレーの2段階取得 POST: 署名済み kind 3 イベントを /api/publish に委譲
- app/api/social/mutes/route.js: ミュートリスト取得・更新 API GET: nostrdb → リレーの2段階取得 (p/e/t/word タグ全対応) POST: 署名済み kind 10000 イベントを /api/publish に委譲
- lib/rust-engine-manager.js: getFollowList / getMuteList ヘルパー追加
- lib/nostr.js: fetchFollowListCached / fetchMuteListCached を /api/social/* 経由に更新 (失敗時は既存 JS にフォールバック)
- CLAUDE.md: Step 6 を ✅ に更新、使用方法を追記

https://claude.ai/code/session_01DXZC8NqNBnbyY59jZWGtwZ