### PR TITLE
feat: Step 7 — DM取得・NIP-50検索の API 化

### DIFF
--- a/app/api/dm/route.js
+++ b/app/api/dm/route.js
@@ -1,0 +1,131 @@
+/**
+ * GET /api/dm?pubkey=xxx&since=xxx&limit=50
+ *
+ * Fetches NIP-17 gift-wrapped DM events (kind 1059) for a user.
+ *
+ * Returns raw gift wrap events — decryption (seal + rumor layers)
+ * is intentionally left to the browser, since the private key lives
+ * in NIP-07 extensions / Amber / NIP-46 and must never reach the server.
+ *
+ * Strategy:
+ *   1. Query nostrdb local cache (fast, no relay round-trip)
+ *   2. If cache is empty, fetch from relay via Rust engine (loginUser first)
+ *   3. If engine unavailable, return { events: [], source: 'fallback' }
+ *
+ * Query params:
+ *   pubkey  — user's hex pubkey (required)
+ *   since   — Unix timestamp; only return events after this (optional)
+ *   limit   — max events to return, default 50, max 200 (optional)
+ *
+ * Response:
+ *   { events: NostrEvent[], source: 'nostrdb' | 'rust' | 'fallback' }
+ *
+ * POST /api/dm
+ *
+ * Publish a signed gift-wrap event (kind 1059).
+ * Delegates to /api/publish for signature validation and relay broadcast.
+ *
+ * Request body:
+ *   { event: SignedNostrEvent }   — pre-signed kind 1059 gift wrap
+ *
+ * Response:
+ *   { id: string, relays: string[], source: string }
+ */
+
+import { getOrCreateEngine, loginUser } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url)
+  const pubkey = searchParams.get('pubkey')
+  const sinceParam = searchParams.get('since')
+  const limitParam = searchParams.get('limit')
+
+  if (!pubkey || !/^[0-9a-f]{64}$/.test(pubkey)) {
+    return Response.json({ error: 'Invalid pubkey' }, { status: 400 })
+  }
+
+  const limit = Math.min(parseInt(limitParam) || 50, 200)
+  const since = sinceParam ? parseInt(sinceParam) : null
+
+  const engine = await getOrCreateEngine()
+
+  if (!engine) {
+    return Response.json({ events: [], source: 'fallback' })
+  }
+
+  // ── Step 1: Query nostrdb local cache ─────────────────────────
+  try {
+    const localFilter = JSON.stringify({
+      kinds: [1059],
+      '#p': [pubkey],
+      ...(since ? { since } : {}),
+      limit,
+    })
+    const localJsons = await engine.queryLocal(localFilter)
+
+    if (localJsons && localJsons.length > 0) {
+      const events = localJsons.map(j => JSON.parse(j))
+      return Response.json({ events, source: 'nostrdb' })
+    }
+  } catch (err) {
+    console.warn('[api/dm] queryLocal failed:', err.message)
+  }
+
+  // ── Step 2: Fetch from relay via Rust engine ──────────────────
+  // loginUser sets the pubkey context so fetch_dms knows which inbox to query
+  try {
+    await loginUser(pubkey)
+    const eventJsons = await engine.fetchDms(since ? since * 1.0 : null, limit)
+    const events = eventJsons.map(j => JSON.parse(j))
+    return Response.json({ events, source: 'rust' })
+  } catch (err) {
+    console.warn('[api/dm] fetchDms failed:', err.message)
+    return Response.json({ events: [], source: 'fallback' })
+  }
+}
+
+export async function POST(req) {
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { event } = body
+
+  if (!event) {
+    return Response.json({ error: 'Missing event' }, { status: 400 })
+  }
+
+  // Gift wrap events are kind 1059
+  if (event.kind !== 1059) {
+    return Response.json({ error: 'Event must be kind 1059 (gift wrap)' }, { status: 400 })
+  }
+
+  if (!event.id || !event.pubkey || !event.sig) {
+    return Response.json({ error: 'Missing required fields: id, pubkey, sig' }, { status: 400 })
+  }
+
+  // Delegate to /api/publish for signature validation and relay broadcast
+  try {
+    const publishRes = await fetch(new URL('/api/publish', req.url).toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event }),
+    })
+
+    const result = await publishRes.json()
+
+    if (!publishRes.ok) {
+      return Response.json(result, { status: publishRes.status })
+    }
+
+    return Response.json(result)
+  } catch (err) {
+    console.error('[api/dm] publish delegation failed:', err.message)
+    return Response.json({ error: 'Failed to publish event' }, { status: 500 })
+  }
+}

--- a/app/api/search/route.js
+++ b/app/api/search/route.js
@@ -1,0 +1,64 @@
+/**
+ * GET /api/search?q=xxx&limit=20
+ *
+ * Full-text search via NIP-50, proxied through the Rust engine's unified
+ * relay pool (connects to wss://search.nos.today by default).
+ *
+ * Moving search to the server-side Rust engine avoids the need for the
+ * browser to maintain a separate WebSocket connection to a search relay,
+ * and allows nostrdb to cache search results for future queries.
+ *
+ * Strategy:
+ *   1. Validate query param
+ *   2. Call engine.search(query, limit) → NIP-50 relay fetch
+ *   3. Store returned events into nostrdb via engine.storeEvent() (background)
+ *   4. If engine unavailable, return { results: [], source: 'fallback' }
+ *
+ * Query params:
+ *   q      — search query string (required)
+ *   limit  — max results, default 50, max 100 (optional)
+ *
+ * Response:
+ *   { results: NostrEvent[], source: 'rust' | 'fallback' }
+ */
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url)
+  const q = searchParams.get('q')
+  const limitParam = searchParams.get('limit')
+
+  if (!q || !q.trim()) {
+    return Response.json({ error: 'Missing query parameter: q' }, { status: 400 })
+  }
+
+  const limit = Math.min(parseInt(limitParam) || 50, 100)
+  const query = q.trim()
+
+  const engine = await getOrCreateEngine()
+
+  if (!engine) {
+    return Response.json({ results: [], source: 'fallback' })
+  }
+
+  try {
+    const eventJsons = await engine.search(query, limit)
+    const results = eventJsons.map(j => JSON.parse(j))
+
+    // Persist search results into nostrdb in the background so future
+    // local queries can find them without hitting the relay again.
+    if (results.length > 0) {
+      Promise.allSettled(
+        results.map(event => engine.storeEvent(JSON.stringify(event)))
+      ).catch(() => {/* ignore background errors */})
+    }
+
+    return Response.json({ results, source: 'rust' })
+  } catch (err) {
+    console.warn('[api/search] search failed:', err.message)
+    return Response.json({ results: [], source: 'fallback' })
+  }
+}

--- a/lib/rust-engine-manager.js
+++ b/lib/rust-engine-manager.js
@@ -222,6 +222,72 @@ async function getMuteList(pubkey) {
   }
 }
 
+// ──────────────────────────────────────────────
+// DM helpers (Step 7: DM 取得・検索の API 化)
+// ──────────────────────────────────────────────
+
+/**
+ * Fetch NIP-17 gift-wrapped DM events (kind 1059) for a pubkey.
+ * Queries nostrdb first; falls back to relay fetch via Rust engine.
+ *
+ * Returns raw gift wrap events — decryption must happen in the browser.
+ *
+ * @param {string} pubkey - User's hex pubkey (recipient)
+ * @param {number|null} since - Unix timestamp lower bound (optional)
+ * @param {number} limit - Max events to return (default 50)
+ * @returns {Promise<object[]|null>} Array of gift wrap events, or null if unavailable
+ */
+async function fetchDms(pubkey, since = null, limit = 50) {
+  // Try nostrdb first
+  const engine = await getOrCreateEngine()
+  if (!engine) return null
+
+  try {
+    const localFilter = JSON.stringify({
+      kinds: [1059],
+      '#p': [pubkey],
+      ...(since ? { since } : {}),
+      limit,
+    })
+    const localJsons = await engine.queryLocal(localFilter)
+    if (localJsons && localJsons.length > 0) {
+      return localJsons.map(j => JSON.parse(j))
+    }
+  } catch (e) {
+    console.warn('[engine-manager] fetchDms queryLocal failed:', e.message)
+  }
+
+  // Fall back to relay fetch (requires login)
+  try {
+    await loginUser(pubkey)
+    const eventJsons = await engine.fetchDms(since ? since * 1.0 : null, limit)
+    return eventJsons.map(j => JSON.parse(j))
+  } catch (e) {
+    console.error('[engine-manager] fetchDms relay failed:', e.message)
+    return null
+  }
+}
+
+/**
+ * Full-text search via NIP-50, proxied through the Rust engine's relay pool.
+ *
+ * @param {string} query - Search query string
+ * @param {number} limit - Max results (default 50)
+ * @returns {Promise<object[]|null>} Array of matching events, or null if unavailable
+ */
+async function searchEvents(query, limit = 50) {
+  const engine = await getOrCreateEngine()
+  if (!engine) return null
+
+  try {
+    const eventJsons = await engine.search(query, limit)
+    return eventJsons.map(j => JSON.parse(j))
+  } catch (e) {
+    console.error('[engine-manager] searchEvents failed:', e.message)
+    return null
+  }
+}
+
 module.exports = {
   getOrCreateEngine,
   loginUser,
@@ -232,4 +298,6 @@ module.exports = {
   reconnectRelays,
   getFollowList,
   getMuteList,
+  fetchDms,
+  searchEvents,
 }


### PR DESCRIPTION
- app/api/dm/route.js: GET /api/dm (nostrdb→relay 2段階 gift wrap 取得) POST /api/dm (kind 1059 gift wrap を /api/publish に委譲)
- app/api/search/route.js: GET /api/search (NIP-50 全文検索、結果を nostrdb に自動キャッシュ)
- lib/rust-engine-manager.js: fetchDms() / searchEvents() ヘルパー追加
- components/TalkTab.js: loadConversations / openChat で /api/dm を優先、JS fallback 維持
- components/SearchModal.js: テキスト検索で /api/search を優先、JS fallback 維持
- CLAUDE.md: Step 7 を ✅ に更新、API 使い方・アーキテクチャ図を追記

DM復号 (seal→rumor NIP-44) はブラウザ責務のまま維持。
サーバーは暗号化された gift wrap を返すだけで秘密鍵に触れない。

https://claude.ai/code/session_01KfCpSQQ8FcKjmVP3Ua6wA1