### PR TITLE
feat: Step 8 — リアルタイム配信の Rust SSE プロキシ化

### DIFF
--- a/app/api/stream/route.js
+++ b/app/api/stream/route.js
@@ -1,0 +1,139 @@
+/**
+ * /api/stream — Server-Sent Events (SSE) proxy for Nostr relay subscriptions.
+ *
+ * Step 8: Rust SSE プロキシ実装
+ *
+ * Architecture:
+ *   Browser (EventSource) → GET /api/stream?filter={...}
+ *     → Rust engine.subscribeStream(filter)   ← REQ sent to all relays
+ *     → polling loop: engine.pollSubscription()
+ *     → data: {eventJson}\n\n                 ← SSE push to browser
+ *     (on disconnect) → engine.unsubscribeStream()  ← CLOSE sent to relays
+ *
+ * Runtime: Node.js (NOT Edge) — required for native .node module access.
+ */
+
+export const runtime = 'nodejs'
+
+import { getOrCreateEngine } from '@/lib/rust-engine-manager'
+
+// Poll interval in milliseconds — how often we check the Rust event buffer.
+// 50 ms gives a good balance between latency and CPU usage.
+const POLL_INTERVAL_MS = 50
+
+// Heartbeat interval — keeps the SSE connection alive through proxies/firewalls.
+const HEARTBEAT_INTERVAL_MS = 25_000
+
+// Maximum events drained per poll cycle.
+const MAX_EVENTS_PER_POLL = 50
+
+export async function GET(req) {
+  const { searchParams } = new URL(req.url)
+  const filterJson = searchParams.get('filter')
+
+  if (!filterJson) {
+    return Response.json(
+      { error: 'filter クエリパラメータが必要です' },
+      { status: 400 }
+    )
+  }
+
+  // Validate that filterJson is valid JSON
+  try {
+    JSON.parse(filterJson)
+  } catch {
+    return Response.json(
+      { error: 'filter パラメータが無効な JSON です' },
+      { status: 400 }
+    )
+  }
+
+  const engine = await getOrCreateEngine()
+  if (!engine) {
+    return Response.json(
+      { error: 'Rust エンジンが利用できません', source: 'unavailable' },
+      { status: 503 }
+    )
+  }
+
+  const encoder = new TextEncoder()
+  let subId = null
+  let cancelled = false
+  let heartbeatTimer = null
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enqueue = (data) => {
+        if (!cancelled) {
+          try {
+            controller.enqueue(encoder.encode(data))
+          } catch {
+            // Controller might be closed if client disconnected
+            cancelled = true
+          }
+        }
+      }
+
+      // Send an initial comment to establish the connection immediately.
+      enqueue(': connected\n\n')
+
+      // Heartbeat to keep the connection alive through proxies.
+      heartbeatTimer = setInterval(() => {
+        enqueue(': heartbeat\n\n')
+      }, HEARTBEAT_INTERVAL_MS)
+
+      try {
+        // Start subscription in the Rust engine — sends REQ to all relays.
+        subId = await engine.subscribeStream(filterJson)
+
+        // Poll the event buffer and forward events to the browser.
+        while (!cancelled) {
+          const events = await engine.pollSubscription(subId, MAX_EVENTS_PER_POLL)
+
+          for (const eventJson of events) {
+            enqueue(`data: ${eventJson}\n\n`)
+          }
+
+          // Wait before next poll (yields event loop so Node.js can handle
+          // other requests concurrently).
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+        }
+      } catch (err) {
+        // Send error event before closing.
+        enqueue(`event: error\ndata: ${JSON.stringify({ message: err.message })}\n\n`)
+      } finally {
+        clearInterval(heartbeatTimer)
+        if (subId) {
+          try {
+            await engine.unsubscribeStream(subId)
+          } catch {
+            // Best-effort cleanup
+          }
+        }
+        if (!cancelled) {
+          try {
+            controller.close()
+          } catch {
+            // Already closed
+          }
+        }
+      }
+    },
+
+    cancel() {
+      // Called when the browser closes the EventSource connection.
+      cancelled = true
+      clearInterval(heartbeatTimer)
+      // Cleanup happens in the finally block of start().
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no', // Disable nginx buffering
+    },
+  })
+}

--- a/lib/nostr-sse.js
+++ b/lib/nostr-sse.js
@@ -1,0 +1,168 @@
+/**
+ * nostr-sse.js — Browser SSE client for Nostr real-time subscriptions.
+ *
+ * Step 8: Rust SSE プロキシ対応クライアント
+ *
+ * Replaces `subscribeManaged()` from connection-manager.js for subscriptions
+ * routed through the Rust engine at `/api/stream`.
+ *
+ * The API is intentionally compatible with `subscribeManaged` so that
+ * `useNostrSubscription.js` can switch transports with minimal changes.
+ *
+ * Usage:
+ *   const sub = subscribeSSE(filter, {
+ *     onEvent: (event) => { ... },
+ *     onEose: () => { ... },
+ *     onError: (err) => { ... },
+ *     onReconnect: (attempt) => { ... },
+ *   })
+ *   // Later:
+ *   sub.close()
+ */
+
+const SSE_BASE_URL = '/api/stream'
+
+// Reconnect configuration (mirrors connection-manager.js defaults)
+const RECONNECT = {
+  initialDelayMs: 1000,
+  maxDelayMs: 30_000,
+  backoffMultiplier: 2,
+  maxAttempts: 10,
+}
+
+/**
+ * Subscribe to Nostr events via Rust SSE proxy.
+ *
+ * @param {Object|Object[]} filter - Nostr filter (or array of filters merged as AND).
+ * @param {Object} options
+ * @param {Function} [options.onEvent]      - Called for each received event.
+ * @param {Function} [options.onEose]       - Called when EOSE is received.
+ * @param {Function} [options.onError]      - Called on connection errors.
+ * @param {Function} [options.onReconnect]  - Called before each reconnect attempt.
+ * @param {boolean}  [options.autoReconnect=true]
+ * @param {number}   [options.maxReconnectAttempts=10]
+ * @returns {{ close: Function, getStats: Function }}
+ */
+export function subscribeSSE(filter, options = {}) {
+  const {
+    onEvent,
+    onEose,
+    onError,
+    onReconnect,
+    autoReconnect = true,
+    maxReconnectAttempts = RECONNECT.maxAttempts,
+  } = options
+
+  // Normalize filter — if array, use first (multi-filter AND is rare in practice).
+  const normalizedFilter = Array.isArray(filter) ? filter[0] : filter
+  const filterJson = JSON.stringify(normalizedFilter)
+  const url = `${SSE_BASE_URL}?filter=${encodeURIComponent(filterJson)}`
+
+  let es = null
+  let closed = false
+  let reconnectAttempt = 0
+  let reconnectDelayMs = RECONNECT.initialDelayMs
+  let reconnectTimer = null
+  const seenEventIds = new Set()
+
+  function connect() {
+    if (closed) return
+
+    es = new EventSource(url)
+
+    es.onmessage = (e) => {
+      if (closed) return
+      try {
+        const event = JSON.parse(e.data)
+
+        // Deduplicate events (in case of reconnect overlap)
+        if (event.id && seenEventIds.has(event.id)) return
+        if (event.id) {
+          seenEventIds.add(event.id)
+          // Trim seen-set to avoid unbounded growth
+          if (seenEventIds.size > 2000) {
+            const entries = [...seenEventIds]
+            seenEventIds.clear()
+            entries.slice(-1000).forEach((id) => seenEventIds.add(id))
+          }
+        }
+
+        if (onEvent) onEvent(event)
+      } catch {
+        // Ignore parse errors (e.g. heartbeat comments forwarded as data)
+      }
+    }
+
+    es.addEventListener('eose', () => {
+      if (!closed && onEose) onEose()
+    })
+
+    es.addEventListener('error', (e) => {
+      if (closed) return
+
+      // SSE error — could be a temporary network blip or server restart.
+      if (onError) onError(new Error('SSE connection error'))
+
+      es.close()
+      es = null
+
+      if (autoReconnect && reconnectAttempt < maxReconnectAttempts) {
+        reconnectAttempt++
+        const delay = Math.min(
+          reconnectDelayMs * Math.pow(RECONNECT.backoffMultiplier, reconnectAttempt - 1),
+          RECONNECT.maxDelayMs
+        )
+        if (onReconnect) onReconnect(reconnectAttempt)
+        reconnectTimer = setTimeout(() => {
+          if (!closed) connect()
+        }, delay)
+      }
+    })
+
+    // Reset reconnect counter on successful open
+    es.addEventListener('open', () => {
+      reconnectAttempt = 0
+      reconnectDelayMs = RECONNECT.initialDelayMs
+    })
+  }
+
+  connect()
+
+  return {
+    close() {
+      closed = true
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (es) {
+        es.close()
+        es = null
+      }
+    },
+
+    getStats() {
+      return {
+        reconnectAttempt,
+        readyState: es?.readyState ?? -1,
+        seenEvents: seenEventIds.size,
+      }
+    },
+  }
+}
+
+/**
+ * Check whether the SSE endpoint is available (Rust engine running).
+ * Returns true if the engine is up, false otherwise.
+ * Used by useNostrSubscription to decide which transport to use.
+ */
+export async function isSseAvailable() {
+  try {
+    const res = await fetch('/api/rust-status', { method: 'GET' })
+    if (!res.ok) return false
+    const data = await res.json()
+    return data?.rustEngine?.available === true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
ブラウザの WebSocket 購読 (nostr-tools SimplePool) を
Rust エンジン経由の SSE ストリームに置き換える。

## 変更内容

### Rust エンジン (nurunuru-core/src/engine.rs)
- `subscribe_stream(filter)` — nostr-sdk `client.subscribe()` で REQ 送信、 `client.notifications()` の broadcast channel から受信してバッファに蓄積
- `poll_subscription(sub_id, max)` — バッファからイベントをドレイン
- `unsubscribe_stream(sub_id)` — CLOSE 送信 + バッファ削除
- バックグラウンドタスクの終了は `Weak<Arc>` パターンで自動管理

### NAPI バインディング (nurunuru-napi/src/lib.rs)
- `subscribeStream(filterJson)` → `Promise<String>` (sub_id)
- `pollSubscription(id, maxCount)` → `Promise<Vec<String>>`
- `unsubscribeStream(id)` → `Promise<()>`

### Next.js SSE エンドポイント (app/api/stream/route.js) [新規]
- `GET /api/stream?filter=xxx` → `text/event-stream`
- `export const runtime = 'nodejs'` (Node.js Runtime 必須)
- 50ms ポーリングループ + 25秒ハートビート
- disconnect 時に自動クリーンアップ

### SSE クライアント (lib/nostr-sse.js) [新規]
- `subscribeSSE(filter, callbacks)` — subscribeManaged() と同一インターフェース
- 指数バックオフ付き自動再接続
- イベント重複排除

### React Hook 更新 (hooks/useNostrSubscription.js)
- `transport: 'auto'` — Rust エンジン稼働時は SSE 優先、未稼働時は WebSocket
- `transport: 'sse'` / `'websocket'` で固定も可能
- `activeTransport` 状態を追加

https://claude.ai/code/session_01EEbRfNjuBEHhdeJkxP6HKJ