### PR TITLE
fix: 検索履歴の長い文字列によるレイアウト崩れを修正

### DIFF
--- a/components/SearchModal.js
+++ b/components/SearchModal.js
@@ -635,11 +635,12 @@ export default function SearchModal({ pubkey, onClose, onViewProfile, initialQue
                 {recentSearches.map((search, i) => (
                   <div
                     key={i}
-                    className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-[var(--bg-secondary)] text-sm"
+                    className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-[var(--bg-secondary)] text-sm max-w-[200px] min-w-0"
                   >
                     <button
                       onClick={() => { setQuery(search); handleSearch(search); }}
-                      className="text-[var(--text-primary)] hover:text-[var(--line-green)]"
+                      className="text-[var(--text-primary)] hover:text-[var(--line-green)] truncate min-w-0"
+                      title={search}
                     >
                       {search}
                     </button>


### PR DESCRIPTION
npub等の長い文字列が検索履歴チップ内で折り返されず画面外へ突き抜ける問題を修正。
チップに max-w-[200px] で最大幅を設定し、テキストに truncate を適用して
省略記号で切り詰め表示するようにした。title 属性でホバー時にフル文字列を確認可能。

Closes #55

https://claude.ai/code/session_019qfRthCEzAa27a8mEGyTkj