### PR TITLE
fix: prevent text wrapping in post modal header during image upload

### DIFF
--- a/components/HomeTab.js
+++ b/components/HomeTab.js
@@ -688,11 +688,11 @@ const HomeTab = forwardRef(function HomeTab({ pubkey, onLogout, onStartDM, onHas
       if (imageFiles.length > 0) {
         try {
           setUploadingPostImage(true)
-          setUploadProgress(`画像をアップロード中... (0/${imageFiles.length})`)
+          setUploadProgress(`アップロード中... (0/${imageFiles.length})`)
 
           const { urls: uploadedUrls, errors } = await uploadImagesInParallel(imageFiles, {
             onProgress: (current, total) => {
-              setUploadProgress(`画像をアップロード中... (${current}/${total})`)
+              setUploadProgress(`アップロード中... (${current}/${total})`)
             }
           })
 
@@ -1357,14 +1357,14 @@ const HomeTab = forwardRef(function HomeTab({ pubkey, onLogout, onStartDM, onHas
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between p-4 border-b border-[var(--border-color)] flex-shrink-0">
-              <button onClick={() => { setShowPostModal(false); setImageFiles([]); setImagePreviews([]) }} className="text-[var(--text-secondary)] action-btn">
+              <button onClick={() => { setShowPostModal(false); setImageFiles([]); setImagePreviews([]) }} className="text-[var(--text-secondary)] action-btn whitespace-nowrap flex-shrink-0">
                 キャンセル
               </button>
-              <span className="font-semibold text-[var(--text-primary)]">新規投稿</span>
+              <span className="font-semibold text-[var(--text-primary)] whitespace-nowrap flex-shrink-0">新規投稿</span>
               <button
                 onClick={handlePost}
                 disabled={posting || uploadingPostImage || (!newPost.trim() && imageFiles.length === 0)}
-                className="btn-line text-sm py-1.5 px-4 disabled:opacity-50"
+                className="btn-line text-sm py-1.5 px-4 disabled:opacity-50 whitespace-nowrap flex-shrink-0"
               >
                 {uploadingPostImage ? uploadProgress : posting ? '投稿中...' : '投稿'}
               </button>

--- a/components/TimelineTab.js
+++ b/components/TimelineTab.js
@@ -1287,11 +1287,11 @@ const TimelineTab = forwardRef(function TimelineTab({ pubkey, onStartDM, scrollC
       if (imageFiles.length > 0) {
         try {
           setUploadingPostImage(true)
-          setUploadProgress(`画像をアップロード中... (0/${imageFiles.length})`)
+          setUploadProgress(`アップロード中... (0/${imageFiles.length})`)
 
           const { urls: uploadedUrls, errors } = await uploadImagesInParallel(imageFiles, {
             onProgress: (current, total) => {
-              setUploadProgress(`画像をアップロード中... (${current}/${total})`)
+              setUploadProgress(`アップロード中... (${current}/${total})`)
             }
           })
 
@@ -1520,14 +1520,14 @@ const TimelineTab = forwardRef(function TimelineTab({ pubkey, onStartDM, scrollC
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between p-4 border-b border-[var(--border-color)] flex-shrink-0">
-              <button onClick={() => { setShowPostModal(false); setImageFiles([]); setImagePreviews([]) }} className="text-[var(--text-secondary)] action-btn">
+              <button onClick={() => { setShowPostModal(false); setImageFiles([]); setImagePreviews([]) }} className="text-[var(--text-secondary)] action-btn whitespace-nowrap flex-shrink-0">
                 キャンセル
               </button>
-              <span className="font-semibold text-[var(--text-primary)]">新規投稿</span>
+              <span className="font-semibold text-[var(--text-primary)] whitespace-nowrap flex-shrink-0">新規投稿</span>
               <button
                 onClick={handlePost}
                 disabled={posting || uploadingPostImage || (!newPost.trim() && imageFiles.length === 0)}
-                className="btn-line text-sm py-1.5 px-4 disabled:opacity-50"
+                className="btn-line text-sm py-1.5 px-4 disabled:opacity-50 whitespace-nowrap flex-shrink-0"
               >
                 {uploadingPostImage ? uploadProgress : posting ? '投稿中...' : '投稿'}
               </button>

--- a/src/ui/components/post/PostModal.tsx
+++ b/src/ui/components/post/PostModal.tsx
@@ -126,16 +126,16 @@ export function PostModal({
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-[var(--border-color)] flex-shrink-0">
-          <button onClick={handleClose} className="text-[var(--text-secondary)] action-btn">
+          <button onClick={handleClose} className="text-[var(--text-secondary)] action-btn whitespace-nowrap flex-shrink-0">
             キャンセル
           </button>
-          <span className="font-semibold text-[var(--text-primary)]">新規投稿</span>
+          <span className="font-semibold text-[var(--text-primary)] whitespace-nowrap flex-shrink-0">新規投稿</span>
           <button
             onClick={handleSubmit}
             disabled={isSubmitDisabled}
-            className="btn-line text-sm py-1.5 px-4 disabled:opacity-50"
+            className="btn-line text-sm py-1.5 px-4 disabled:opacity-50 whitespace-nowrap flex-shrink-0"
           >
-            {uploadingImage ? uploadProgress || '画像アップロード中...' : posting ? '投稿中...' : '投稿'}
+            {uploadingImage ? uploadProgress || 'アップロード中...' : posting ? '投稿中...' : '投稿'}
           </button>
         </div>
 


### PR DESCRIPTION
Add `whitespace-nowrap` and `flex-shrink-0` to the キャンセル button and 新規投稿 title so they never break across multiple lines. Also apply the same classes to the upload-progress button to keep it on one line. Shorten the upload progress label from 「画像をアップロード中...」to 「アップロード中...」to reduce the button's natural width.

Fixes #75

https://claude.ai/code/session_01Xch7oMzi51CBPdKn1cGAnn