### PR TITLE
Fix profile image and banner upload failure

### DIFF
--- a/components/HomeTab.js
+++ b/components/HomeTab.js
@@ -16,6 +16,7 @@ import {
   hasNip07,
   verifyNip05,
   encodeNpub,
+  uploadImage,
   fetchProfileCached,
   fetchProfilesBatch,
   getAllCachedProfiles,


### PR DESCRIPTION
Fixed the profile image and banner upload failure by adding the missing `uploadImage` import in `components/HomeTab.js`. Verified the fix and confirmed that other components are not affected.

---
*PR created automatically by Jules for task [879206616703314720](https://jules.google.com/task/879206616703314720) started by @tami1A84*