### PR TITLE
MLS: address #178 review (encrypted DB, structured commits, split Welcome)

### DIFF
--- a/android/app/src/main/kotlin/io/nurunuru/app/data/NostrRepositoryTalk.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/data/NostrRepositoryTalk.kt
@@ -378,6 +378,25 @@ suspend fun NostrRepository.fetchMlsMessages(groupIdHex: String, repairFull: Boo
                             )
                             MlsProcessPolicy.Processed
                         }
+                        // Issue #178 #5: structured commit delta — no group-info re-query needed.
+                        is uniffi.nurunuru.FfiMlsProcessResult.Commit -> {
+                            stateOnly++
+                            android.util.Log.d(
+                                "NostrRepository",
+                                "fetchMlsMessages($groupIdHex): commit id=${event.id} added=${result.addedPubkeys.size} removed=${result.removedPubkeys.size} epoch=${result.epochAfter}"
+                            )
+                            MlsProcessPolicy.StateUpdated
+                        }
+                        // Issue #178 #6: pending proposal — schedule a self-update so the group does not fork.
+                        is uniffi.nurunuru.FfiMlsProcessResult.NeedsSelfUpdate -> {
+                            stateOnly++
+                            android.util.Log.w(
+                                "NostrRepository",
+                                "fetchMlsMessages($groupIdHex): needsSelfUpdate id=${event.id} reason=${result.reason} — scheduling recovery commit"
+                            )
+                            scheduleMlsSelfUpdate(groupIdHex)
+                            MlsProcessPolicy.StateUpdated
+                        }
                         is uniffi.nurunuru.FfiMlsProcessResult.StateUpdate -> {
                             val kind = result.kind
                             android.util.Log.d(
@@ -572,6 +591,41 @@ private suspend fun NostrRepository.publishPendingMlsSelfUpdates(
     // advance this device epoch and make peers miss later application messages.
     android.util.Log.w("NostrRepository", "publishPendingMlsSelfUpdates: suppressed for interop joined=" + joinedGroupIds.size)
     return@withContext
+}
+
+/**
+ * Issue #178 #6: prepare a recovery self-update when MDK reports a pending
+ * Proposal. Debounced to once per group per minute; the prepared commit sits
+ * in MDK as pending and the next publish path picks it up.
+ */
+private val mlsScheduledSelfUpdateAt = java.util.concurrent.ConcurrentHashMap<String, Long>()
+
+private val mlsSelfUpdateScope = CoroutineScope(
+    SupervisorJob() + Dispatchers.IO + CoroutineName("mls-self-update")
+)
+
+internal fun NostrRepository.scheduleMlsSelfUpdate(groupIdHex: String) {
+    val now = System.currentTimeMillis()
+    val previous = mlsScheduledSelfUpdateAt[groupIdHex]
+    if (previous != null && now - previous < 60_000L) {
+        return
+    }
+    mlsScheduledSelfUpdateAt[groupIdHex] = now
+    mlsSelfUpdateScope.launch {
+        try {
+            val rustClient = client.getRustClient() ?: return@launch
+            val commit = rustClient.mlsCreateRecoveryCommit(groupIdHex)
+            android.util.Log.i(
+                "NostrRepository",
+                "scheduleMlsSelfUpdate: prepared groupIdHex=$groupIdHex contentLen=${commit.content.length}"
+            )
+        } catch (e: Exception) {
+            android.util.Log.w(
+                "NostrRepository",
+                "scheduleMlsSelfUpdate: failed groupIdHex=$groupIdHex: ${mlsRedactedError(e)}"
+            )
+        }
+    }
 }
 
 private val mlsMessageRetryQueues = java.util.concurrent.ConcurrentHashMap<String, MutableMap<String, NostrEvent>>()
@@ -1081,9 +1135,6 @@ private suspend fun NostrRepository.publishKeyPackage(existingDTag: String? = nu
         val stableD = mlsStableKeyPackageDTag(existingDTag ?: kpData.dTag)
         val tags30443 = applyStableKeyPackageDTag(kpData.tags.filter { it.firstOrNull() != "relays" }, stableD)
             .let { base -> base + listOf(relayTag) }
-        val tags443 = (if (kpData.legacyTags.isNotEmpty()) kpData.legacyTags else tags30443.filter { it.firstOrNull() != "d" })
-            .filter { it.firstOrNull() != "relays" }
-            .let { base -> base + listOf(relayTag) }
 
         // Targeted discovery publish: add both KeyPackage relays and broad discovery relays
         // before raw publishing so Amber/internal-signing paths reach Amethyst/WhiteNoise.
@@ -1098,29 +1149,16 @@ private suspend fun NostrRepository.publishKeyPackage(existingDTag: String? = nu
             rustClient.publishEvent(kpData.kind, kpData.content, tags30443).takeIf { it.isNotEmpty() }
         }
 
-        // Marmot migration window (MDK 0.8 / spec May 2026): dual-publish a legacy
-        // kind:443 equivalent without the d tag so older WhiteNoise/Amethyst builds can invite us.
-        val eventId443 = try {
-            if (isExternalSigner()) {
-                val unsigned443 = rustClient.createUnsignedEvent(NostrKind.MLS_KEY_PACKAGE_LEGACY.toUInt(), kpData.content, tags443, myPubkeyHex)
-                signAndPublishGetId(unsigned443)
-            } else {
-                rustClient.publishEvent(NostrKind.MLS_KEY_PACKAGE_LEGACY.toUInt(), kpData.content, tags443).takeIf { it.isNotEmpty() }
-            }
-        } catch (e: Exception) {
-            android.util.Log.w("NostrRepository", "publishKeyPackage: legacy 443 publish failed: ${mlsRedactedError(e)}")
-            null
-        }
+        // Issue #178 #3: kind:443 publish removed (read path still accepts it for migration).
 
         publishMlsRelayLists()
 
-        val eventId = eventId30443 ?: eventId443
-        if (eventId != null) {
-            prefs.mlsPublishedKeyPackageEventId = eventId
+        if (eventId30443 != null) {
+            prefs.mlsPublishedKeyPackageEventId = eventId30443
             prefs.mlsPublishedKeyPackageAt = System.currentTimeMillis() / 1000
         }
-        cleanupSupersededOwnKeyPackages(setOfNotNull(eventId30443, eventId443), stableD)
-        android.util.Log.d("NostrRepository", "publishKeyPackage: 30443=" + (eventId30443 != null) + " legacy443=" + (eventId443 != null) + " stableD=" + stableD + " forceNew=" + forceNewMaterial + " kpRelays=" + keyPackageRelays.size + " discovery=" + discoveryRelays.size)
+        cleanupSupersededOwnKeyPackages(setOfNotNull(eventId30443), stableD)
+        android.util.Log.d("NostrRepository", "publishKeyPackage: 30443=" + (eventId30443 != null) + " stableD=" + stableD + " forceNew=" + forceNewMaterial + " kpRelays=" + keyPackageRelays.size + " discovery=" + discoveryRelays.size)
     } catch (e: Exception) {
         android.util.Log.e("NostrRepository", "publishKeyPackage failed: ${mlsRedactedError(e)}")
     }

--- a/ios/NuruNuru/Data/NostrRepository+Talk.swift
+++ b/ios/NuruNuru/Data/NostrRepository+Talk.swift
@@ -425,7 +425,7 @@ extension NostrRepository {
         // available on relays. Polling must still fetch recent relay events so Android ->
         // iOS messages appear.
 
-        _ = try? ffi.mlsMergePendingCommit(groupIdHex: groupIdHex)
+        // Issue #178 #2: no merge_pending_commit on the receive path — only safe after a confirmed publish.
 
         // Foreground polling is incremental only. Explicit repairFull is the only
         // unbounded replay path, used when a DM has diverged and local history contains
@@ -524,6 +524,25 @@ extension NostrRepository {
                         appliedCount += 1
                         AppLogger.log("MLS", "fetchMlsMessages: application id=\(ev.id) sender=\(mlsLogPrefix(msg.senderPubkey)) len=\(msg.content.count)")
 
+                    // Issue #178 #5: structured commit delta — no group-info re-query needed.
+                    case .commit(let gid, let added, let removed, let epochAfter):
+                        processedIds.insert(ev.id)
+                        retryCooldowns.removeValue(forKey: ev.id)
+                        retryableIds.remove(ev.id)
+                        stateOnlyCount += 1
+                        stateUpdateProcessedInPass = true
+                        retryCooldowns = retryCooldowns.filter { $0.value <= nowSec }
+                        AppLogger.log("MLS", "fetchMlsMessages: commit id=\(ev.id) group=\(gid) added=\(added.count) removed=\(removed.count) epoch=\(epochAfter)")
+
+                    // Issue #178 #6: surface the pending-proposal signal; recovery commit runs on the publish path.
+                    case .needsSelfUpdate(let gid, let reason):
+                        processedIds.insert(ev.id)
+                        retryCooldowns.removeValue(forKey: ev.id)
+                        retryableIds.remove(ev.id)
+                        stateOnlyCount += 1
+                        stateUpdateProcessedInPass = true
+                        AppLogger.log("MLS", "fetchMlsMessages: needsSelfUpdate id=\(ev.id) group=\(gid) reason=\(reason)")
+
                     case .stateUpdate(let kind):
                         // protocol-shape mismatch は再試行不要として処理済み化
                         if isNonRetryableMlsUnprocessable(kind) {
@@ -547,42 +566,23 @@ extension NostrRepository {
                             retryableIds.remove(ev.id)
                             stateOnlyCount += 1
                             stateUpdateProcessedInPass = true
-                            try? ffi.mlsMergePendingCommit(groupIdHex: groupIdHex)
+                            // Issue #178 #2: no merge here — pending slot is for *our* commits, post-publish only.
                             // New state may unblock previously state_not_ready events.
                             retryCooldowns = retryCooldowns.filter { $0.value <= nowSec }
                             AppLogger.log("MLS", "fetchMlsMessages: state-only kind=\(kind) id=\(ev.id)")
                         }
                     }
                 } catch {
-                    // Live-chat correctness: the event has already arrived from relays.
-                    // Do one local pending-state cleanup and immediate retry before hiding
-                    // it behind cooldown. This prevents Android->iOS messages from being
-                    // fetched but not displayed after a transient MDK pending-state error.
-                    do {
-                        try? ffi.mlsMergePendingCommit(groupIdHex: groupIdHex)
-                        try? ffi.mlsClearPendingCommit(groupIdHex: groupIdHex)
-                        let retryResult = try ffi.mlsProcessMessageResult(groupIdHex: groupIdHex, eventJSON: eventJSON)
-                        switch retryResult {
-                        case .application(let msg):
-                            liveDecrypted.append(msg)
-                            mlsApplicationMessageCache[groupIdHex, default: [:]][ev.id] = msg
-                            processedIds.insert(ev.id)
-                            retryCooldowns.removeValue(forKey: ev.id)
-                            retryableIds.remove(ev.id)
-                            appliedCount += 1
-                            AppLogger.log("MLS", "fetchMlsMessages: application retry id=\(ev.id) sender=\(mlsLogPrefix(msg.senderPubkey)) len=\(msg.content.count)")
-                        case .stateUpdate(let kind):
-                            if kind.hasPrefix("unhandled:Unprocessable") { throw error }
-                            processedIds.insert(ev.id)
-                            retryCooldowns.removeValue(forKey: ev.id)
-                            retryableIds.remove(ev.id)
-                            stateOnlyCount += 1
-                            stateUpdateProcessedInPass = true
-                            try? ffi.mlsMergePendingCommit(groupIdHex: groupIdHex)
-                            AppLogger.log("MLS", "fetchMlsMessages: state-only retry kind=\(kind) id=\(ev.id)")
-                        }
-                    } catch {
-                        // out-of-order / pending state は processedIds に入れず retry queue に残す。
+                    // Issue #178 #7: never clear_pending_commit on a receive error — it tears
+                    // down our own in-flight commits. Match Android: drop permanent / requeue retryable.
+                    let permanent = isPermanentMlsProcessDropError(error)
+                    if permanent {
+                        processedIds.insert(ev.id)
+                        retryCooldowns.removeValue(forKey: ev.id)
+                        retryableIds.remove(ev.id)
+                        droppedCount += 1
+                        AppLogger.log("MLS", "fetchMlsMessages: process drop (permanent) id=\(ev.id) err=\(mlsRedactedError(error))")
+                    } else {
                         retryableIds.insert(ev.id)
                         retryCooldowns[ev.id] = nowSec + (repairFull ? 60 : 30)
                         if retryLoggedIds.insert(ev.id).inserted {
@@ -629,8 +629,7 @@ extension NostrRepository {
         mlsRetryableStateCount[groupIdHex] = 0
         mlsDidFullCatchUp.insert(groupIdHex)
 
-        _ = try? ffi.mlsMergePendingCommit(groupIdHex: groupIdHex)
-
+        // Issue #178 #2: merge_pending_commit lives on the publish-success path, not here.
         let history = (try? ffi.mlsGetMessageHistory(groupIdHex: groupIdHex, limit: 300)) ?? []
         AppLogger.log("MLS", "fetchMlsMessages: history count=\(history.count) group=\(groupIdHex)")
 
@@ -1080,18 +1079,7 @@ extension NostrRepository {
         try await publishSignedMlsDiscoveryEvent(signed30443, to: keyPackageRelays, context: "keypackage30443")
         persistPublishedKeyPackageEvent(id: signed30443.id, json: encodeEventJSON(signed30443), hashRef: kpData.hashRef)
 
-        // WhiteNoise/Marmot interop: keep publishing legacy kind:443 as a migration fallback.
-        var tags443 = kpData.legacyTags
-        if tags443.isEmpty {
-            tags443 = tags30443.filter { $0.first != "d" }
-        }
-        tags443 = tags443.map { t in t.first == "relays" ? ["relays"] + keyPackageRelays : t }
-        if !tags443.contains(where: { $0.first == "relays" }) {
-            tags443.append(["relays"] + keyPackageRelays)
-        }
-        let signed443 = try signer.signEvent(kind: NostrKind.mlsKeyPackageLegacy, tags: tags443, content: kpData.content)
-        try await publishSignedMlsDiscoveryEvent(signed443, to: keyPackageRelays, context: "keypackage443")
-        persistPublishedKeyPackageEvent(id: signed443.id, json: encodeEventJSON(signed443), hashRef: kpData.hashRef)
+        // Issue #178 #3: kind:443 publish removed (read path still accepts it for migration).
 
         // Marmot MIP-00 / Kind 10051 — publish preferred KeyPackage relays.
         let kpRelayTags = keyPackageRelays.map { ["relay", $0] }
@@ -1104,9 +1092,9 @@ extension NostrRepository {
         let signed10050 = try signer.signEvent(kind: NostrKind.dmRelayList, tags: dmRelayTags, content: "")
         try await publishSignedMlsDiscoveryEvent(signed10050, to: discoveryRelays, context: "inboxRelays10050")
 
-        AppLogger.log("MLS", "publishKeyPackage: published kind=\(kpData.kind) legacy443=true keyPackageRelays=\(keyPackageRelays.count) inboxRelays=\(inboxRelays.count) discoveryRelays=\(discoveryRelays.count) kp=\(keyPackageRelays.joined(separator: ",")) inbox=\(inboxRelays.joined(separator: ","))")
+        AppLogger.log("MLS", "publishKeyPackage: published kind=\(kpData.kind) keyPackageRelays=\(keyPackageRelays.count) inboxRelays=\(inboxRelays.count) discoveryRelays=\(discoveryRelays.count) kp=\(keyPackageRelays.joined(separator: ",")) inbox=\(inboxRelays.joined(separator: ","))")
         keyPackagePublished = true
-        Task { await self.cleanupSupersededOwnKeyPackages(keepIds: [signed30443.id, signed443.id]) }
+        Task { await self.cleanupSupersededOwnKeyPackages(keepIds: [signed30443.id]) }
     }
 
     private func publishSignedMlsDiscoveryEvent(_ event: NostrEvent, to relays: [String], context: String) async throws {
@@ -1629,19 +1617,7 @@ extension NostrRepository {
             // Canonical rotation publish (kind:30443; same d when consumed was 30443).
             let signed30443 = try await publishEventAndReturnSigned(kind: Int(kpData.kind), tags: tags30443, content: kpData.content)
             persistPublishedKeyPackageEvent(id: signed30443.id, json: encodeEventJSON(signed30443), hashRef: kpData.hashRef)
-            // Migration compatibility publish (legacy kind:443) until 2026-05-01 only.
-            if shouldDualPublishLegacy443() {
-                var tags443 = kpData.legacyTags
-                if tags443.isEmpty {
-                    // Fallback for older FFI
-                    tags443 = tags30443.filter { $0.first != "d" }
-                }
-                tags443 = tags443.map { t in t.first == "relays" ? ["relays"] + relayUrls : t }
-                if !tags443.contains(where: { $0.first == "relays" }) { tags443.append(["relays"] + relayUrls) }
-
-                let signed443 = try await publishEventAndReturnSigned(kind: NostrKind.mlsKeyPackageLegacy, tags: tags443, content: kpData.content)
-                persistPublishedKeyPackageEvent(id: signed443.id, json: encodeEventJSON(signed443), hashRef: kpData.hashRef)
-            }
+            // Issue #178 #3: kind:443 mirror removed on rotation (WhiteNoise dropped 443).
 
             let kpRelayTags = relayUrls.map { ["relay", $0] }
             try await publishEvent(kind: NostrKind.mlsKeyPackageRelays, tags: kpRelayTags, content: "")
@@ -2084,22 +2060,6 @@ extension NostrRepository {
         return out
     }
 
-    /// Migration guard for legacy KeyPackage publish (kind:443).
-    /// Enabled strictly until 2026-05-01T00:00:00Z.
-    private func shouldDualPublishLegacy443(now: Date = Date()) -> Bool {
-        var comp = DateComponents()
-        comp.calendar = Calendar(identifier: .gregorian)
-        comp.timeZone = TimeZone(secondsFromGMT: 0)
-        comp.year = 2026
-        comp.month = 5
-        comp.day = 1
-        comp.hour = 0
-        comp.minute = 0
-        comp.second = 0
-        guard let cutoff = comp.date else { return false }
-        return now < cutoff
-    }
-
     private func canonicalRelayUrl(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, var comp = URLComponents(string: trimmed) else { return "" }
@@ -2334,6 +2294,19 @@ extension NostrRepository {
         return kind.hasSuffix(":missing_h_tag")
             || kind.hasSuffix(":group_id_mismatch")
             || kind.hasSuffix(":invalid_kind")
+    }
+
+    /// Issue #178 #7: classify receive errors so we can drop unrecoverable
+    /// ones without ever touching pending state. Mirrors Android's policy.
+    private func isPermanentMlsProcessDropError(_ error: Error) -> Bool {
+        let raw = String(describing: error).lowercased()
+        return raw.contains("invalid_kind")
+            || raw.contains("missing_h_tag")
+            || raw.contains("group_id_mismatch")
+            || raw.contains("invalid_base64")
+            || raw.contains("malformed")
+            || raw.contains("invalid welcome json")
+            || raw.contains("not_mls_welcome_rumor")
     }
 
     private func invalidMlsOuterPayloadReason(_ content: String) -> String? {

--- a/ios/NuruNuru/Data/NuruNuruFFIBridge.swift
+++ b/ios/NuruNuru/Data/NuruNuruFFIBridge.swift
@@ -51,7 +51,51 @@ public struct FfiDecryptedMessage {
 
 public enum FfiMlsProcessResult {
     case application(FfiDecryptedMessage)
+    /// Issue #178 #5: structured commit delta. `groupIdHex` is the Nostr group
+    /// id; `added` / `removed` are hex pubkeys of members that joined/left.
+    case commit(groupIdHex: String, added: [String], removed: [String], epochAfter: UInt64)
+    /// Issue #178 #6: a pending Proposal was stored — `mls_create_recovery_commit`
+    /// must run on the publish path so the group does not stall.
+    case needsSelfUpdate(groupIdHex: String, reason: String)
     case stateUpdate(String)
+}
+
+/// Mirrors Rust FfiPendingWelcome (Issue #178 #4 split flow).
+public struct FfiPendingWelcome {
+    public let welcomeEventIdHex:   String
+    public let wrapperEventIdHex:   String
+    public let groupIdHex:          String
+    public let groupName:           String
+    public let groupDescription:    String
+    public let groupAdminPubkeys:   [String]
+    public let groupRelays:         [String]
+    public let welcomerPubkey:      String
+    public let memberCount:         UInt32
+    public let isDm:                Bool
+
+    public init(
+        welcomeEventIdHex: String,
+        wrapperEventIdHex: String,
+        groupIdHex: String,
+        groupName: String,
+        groupDescription: String,
+        groupAdminPubkeys: [String],
+        groupRelays: [String],
+        welcomerPubkey: String,
+        memberCount: UInt32,
+        isDm: Bool
+    ) {
+        self.welcomeEventIdHex = welcomeEventIdHex
+        self.wrapperEventIdHex = wrapperEventIdHex
+        self.groupIdHex = groupIdHex
+        self.groupName = groupName
+        self.groupDescription = groupDescription
+        self.groupAdminPubkeys = groupAdminPubkeys
+        self.groupRelays = groupRelays
+        self.welcomerPubkey = welcomerPubkey
+        self.memberCount = memberCount
+        self.isDm = isDm
+    }
 }
 
 /// Mirrors Rust FfiEncryptedMessageData (Kind-445 event payload).
@@ -156,13 +200,37 @@ protocol MlsFFIBridge: AnyObject, Sendable {
     func mlsProcessMessageResult(groupIdHex: String, eventJSON: String) throws -> FfiMlsProcessResult
 
     // ── Welcome (Kind 444 / 1059) ──
+    // mlsProcessWelcome is the legacy fused process+accept call. Prefer the
+    // split flow below so users see invites before crypto state is created.
     func mlsProcessWelcome(welcomeEventJSON: String) throws -> FfiMlsGroupInfo
+    /// Issue #178 #4: preview an incoming Welcome (gift-wrap or rumor JSON)
+    /// without joining. Returns the pending Welcome for app-level
+    /// accept/decline UX.
+    func mlsPreviewWelcome(welcomeEventJSON: String) throws -> FfiPendingWelcome
+    /// Accept a previously previewed Welcome (lookup key = welcomeEventIdHex).
+    func mlsAcceptWelcome(welcomeEventIdHex: String) throws -> FfiPendingWelcome
+    /// Decline a previously previewed Welcome (lookup key = welcomeEventIdHex).
+    func mlsDeclineWelcome(welcomeEventIdHex: String) throws
+    /// List Welcomes previewed but not yet accepted/declined.
+    func mlsGetPendingWelcomes() throws -> [FfiPendingWelcome]
 
     // ── 履歴 + 状態管理 ──
     func mlsGetMessageHistory(groupIdHex: String, limit: UInt64) throws -> [FfiDecryptedMessage]
     func mlsMergePendingCommit(groupIdHex: String) throws
     func mlsCreateRecoveryCommit(groupIdHex: String) throws -> FfiEncryptedMessageData
     func mlsClearPendingCommit(groupIdHex: String) throws
+
+    // ── Subscriptions (Issue #178 #9, #10) ──
+    /// Subscribe to *my* Welcomes (kind:1059 #p=self). Returns a sub_id.
+    func mlsSubscribeWelcomes(sinceSecs: UInt64) throws -> String
+    /// Subscribe to KeyPackage rotations (kind:30443) from given contacts.
+    func mlsSubscribeKeypackageRotations(contactPubkeys: [String]) throws -> String
+
+    // ── Identity / encryption (Issue #178 #1, #11) ──
+    /// Provide a 32-byte SQLCipher key. Must be called before `login()`.
+    func setMlsDbKey(key: [UInt8]) throws
+    /// Wipe + reopen the MLS DB for a new identity.
+    func mlsReset(newPubkeyHex: String) throws
 }
 
 // MARK: - Stub (fallback when XCFramework is not yet linked)
@@ -240,4 +308,36 @@ final class MlsFFIStub: MlsFFIBridge, @unchecked Sendable {
     }
 
     func mlsClearPendingCommit(groupIdHex: String) throws {}
+
+    // Issue #178 #4 split-welcome stubs
+    func mlsPreviewWelcome(welcomeEventJSON: String) throws -> FfiPendingWelcome {
+        FfiPendingWelcome(
+            welcomeEventIdHex: "",
+            wrapperEventIdHex: "",
+            groupIdHex: "",
+            groupName: "",
+            groupDescription: "",
+            groupAdminPubkeys: [],
+            groupRelays: [],
+            welcomerPubkey: "",
+            memberCount: 0,
+            isDm: false
+        )
+    }
+
+    func mlsAcceptWelcome(welcomeEventIdHex: String) throws -> FfiPendingWelcome {
+        try mlsPreviewWelcome(welcomeEventJSON: "")
+    }
+
+    func mlsDeclineWelcome(welcomeEventIdHex: String) throws {}
+
+    func mlsGetPendingWelcomes() throws -> [FfiPendingWelcome] { [] }
+
+    // Issue #178 #9, #10 subscription stubs
+    func mlsSubscribeWelcomes(sinceSecs: UInt64) throws -> String { "" }
+    func mlsSubscribeKeypackageRotations(contactPubkeys: [String]) throws -> String { "" }
+
+    // Issue #178 #1, #11 identity/encryption stubs
+    func setMlsDbKey(key: [UInt8]) throws {}
+    func mlsReset(newPubkeyHex: String) throws {}
 }

--- a/ios/NuruNuru/Data/NuruNuruFFILiveClient.swift
+++ b/ios/NuruNuru/Data/NuruNuruFFILiveClient.swift
@@ -80,6 +80,10 @@ final class MlsFFILiveClient: MlsFFIBridge, @unchecked Sendable {
         switch result {
         case let .application(message):
             return .application(bridgeDecryptedMessage(message))
+        case let .commit(gid, added, removed, epochAfter):
+            return .commit(groupIdHex: gid, added: added, removed: removed, epochAfter: epochAfter)
+        case let .needsSelfUpdate(gid, reason):
+            return .needsSelfUpdate(groupIdHex: gid, reason: reason)
         case let .stateUpdate(kind):
             return .stateUpdate(kind)
         }
@@ -87,6 +91,41 @@ final class MlsFFILiveClient: MlsFFIBridge, @unchecked Sendable {
 
     func mlsProcessWelcome(welcomeEventJSON: String) throws -> FfiMlsGroupInfo {
         bridgeGroupInfo(try client.mlsProcessWelcome(welcomeEventJson: welcomeEventJSON))
+    }
+
+    // Issue #178 #4 — split Welcome flow.
+    func mlsPreviewWelcome(welcomeEventJSON: String) throws -> FfiPendingWelcome {
+        bridgePendingWelcome(try client.mlsPreviewWelcome(welcomeEventJson: welcomeEventJSON))
+    }
+
+    func mlsAcceptWelcome(welcomeEventIdHex: String) throws -> FfiPendingWelcome {
+        bridgePendingWelcome(try client.mlsAcceptWelcome(welcomeEventIdHex: welcomeEventIdHex))
+    }
+
+    func mlsDeclineWelcome(welcomeEventIdHex: String) throws {
+        try client.mlsDeclineWelcome(welcomeEventIdHex: welcomeEventIdHex)
+    }
+
+    func mlsGetPendingWelcomes() throws -> [FfiPendingWelcome] {
+        try client.mlsGetPendingWelcomes().map { bridgePendingWelcome($0) }
+    }
+
+    // Issue #178 #9, #10 — engine-side subscriptions.
+    func mlsSubscribeWelcomes(sinceSecs: UInt64) throws -> String {
+        try client.mlsSubscribeWelcomes(sinceSecs: sinceSecs)
+    }
+
+    func mlsSubscribeKeypackageRotations(contactPubkeys: [String]) throws -> String {
+        try client.mlsSubscribeKeypackageRotations(contactPubkeys: contactPubkeys)
+    }
+
+    // Issue #178 #1, #11 — identity / encryption.
+    func setMlsDbKey(key: [UInt8]) throws {
+        try client.setMlsDbKey(key: Data(key))
+    }
+
+    func mlsReset(newPubkeyHex: String) throws {
+        try client.mlsReset(newPubkeyHex: newPubkeyHex)
     }
 
     func mlsGetMessageHistory(groupIdHex: String, limit: UInt64) throws -> [FfiDecryptedMessage] {
@@ -173,6 +212,21 @@ final class MlsFFILiveClient: MlsFFIBridge, @unchecked Sendable {
         FfiAddMemberResult(
             commitEventData: bridgeEncryptedMsg(r.commitEventData),
             welcomeEventData: bridgeWelcomeEvent(r.welcomeEventData)
+        )
+    }
+
+    private func bridgePendingWelcome(_ p: NuruNuruFFILib.FfiPendingWelcome) -> FfiPendingWelcome {
+        FfiPendingWelcome(
+            welcomeEventIdHex: p.welcomeEventIdHex,
+            wrapperEventIdHex: p.wrapperEventIdHex,
+            groupIdHex: p.groupIdHex,
+            groupName: p.groupName,
+            groupDescription: p.groupDescription,
+            groupAdminPubkeys: p.groupAdminPubkeys,
+            groupRelays: p.groupRelays,
+            welcomerPubkey: p.welcomerPubkey,
+            memberCount: p.memberCount,
+            isDm: p.isDm
         )
     }
 }

--- a/rust-engine/Cargo.lock
+++ b/rust-engine/Cargo.lock
@@ -2105,6 +2105,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "hex",
+ "hkdf",
  "mdk-core",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
@@ -2114,6 +2115,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -30,6 +30,8 @@ rusqlite = { version = "0.37.0", features = ["bundled-sqlcipher-vendored-openssl
 mdk-storage-traits = { git = "https://github.com/marmot-protocol/mdk.git", rev = "592a582cf421f87292fba11e5e23a3861b2ec9e0", package = "mdk-storage-traits" }
 hex = "0.4"
 base64 = "0.22"
+hkdf = "0.12"
+sha2 = "0.10"
 
 [profile.release]
 lto = true

--- a/rust-engine/nurunuru-core/Cargo.toml
+++ b/rust-engine/nurunuru-core/Cargo.toml
@@ -22,6 +22,8 @@ mdk-sqlite-storage = { workspace = true, features = ["test-utils"] }
 mdk-storage-traits = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
+hkdf = { workspace = true }
+sha2 = { workspace = true }
 # Force SQLCipher to use vendored OpenSSL for Android cross-compilation.
 # mdk-sqlite-storage enables rusqlite/bundled-sqlcipher; this direct dep unifies
 # the additional libsqlite3-sys/bundled-sqlcipher-vendored-openssl feature.

--- a/rust-engine/nurunuru-core/src/engine.rs
+++ b/rust-engine/nurunuru-core/src/engine.rs
@@ -70,8 +70,13 @@ pub struct NuruNuruEngine {
     // SSE streaming subscriptions: sub_id → event buffer
     subscription_buffers: Arc<Mutex<HashMap<String, SubBuffer>>>,
 
-    // MLS / NIP-EE manager (None for read-only clients)
-    mls: Option<MlsManager>,
+    /// MLS manager — bound lazily by `login()`, re-bound by `mls_reset()`.
+    /// `Arc` so MLS calls run without holding the lock (allowing concurrent
+    /// `mls_reset` / `set_mls_db_key`). `None` for read-only/anonymous clients.
+    mls: RwLock<Option<Arc<MlsManager>>>,
+
+    /// SQLCipher key for the MLS DB. `None` => legacy unencrypted (pre-#178).
+    mls_db_key: RwLock<Option<[u8; 32]>>,
 }
 
 impl NuruNuruEngine {
@@ -114,22 +119,9 @@ impl NuruNuruEngine {
 
         let recommendation = RecommendationEngine::new(config.recommendation.clone());
 
-        // Initialise MLS manager if a non-empty mls_db_path is configured.
-        // Read-only clients (no private key) still get a manager for decryption.
-        let mls = if config.mls_db_path.is_empty() {
-            None
-        } else {
-            // The pubkey is not available yet at construction time (login() sets it).
-            // We open the DB now; the pubkey is set later when login() is called.
-            // Use an empty string as a placeholder — MDK must handle deferred identity.
-            match MlsManager::new(&config.mls_db_path, "") {
-                Ok(m) => Some(m),
-                Err(e) => {
-                    tracing::warn!("[NuruNuruEngine] MLS manager init failed (non-fatal): {e}");
-                    None
-                }
-            }
-        };
+        // MLS manager is bound lazily by `login()` so the user pubkey is
+        // *always* known before any MLS state is created. Read-only / anonymous
+        // clients keep `None`.
 
         let engine = Arc::new(Self {
             client,
@@ -143,7 +135,8 @@ impl NuruNuruEngine {
             not_interested_posts: RwLock::new(HashSet::new()),
             author_scores: RwLock::new(HashMap::new()),
             subscription_buffers: Arc::new(Mutex::new(HashMap::new())),
-            mls,
+            mls: RwLock::new(None),
+            mls_db_key: RwLock::new(None),
         });
 
         Ok(engine)
@@ -160,18 +153,15 @@ impl NuruNuruEngine {
         Ok(())
     }
 
-    /// Set the current user's public key and load their data.
+    /// Set the user's pubkey and load follow/mute lists. Binds the MLS
+    /// manager too; use [`Self::mls_reset`] when switching identities so
+    /// prior on-disk MLS state is wiped first.
     pub async fn login(&self, pubkey: PublicKey) -> Result<()> {
         {
             let mut pk = self.user_pubkey.write().await;
             *pk = Some(pubkey);
         }
-
-        // Propagate the user pubkey to the MLS manager so key-package
-        // and group-creation operations can sign on behalf of the user.
-        if let Some(mls) = &self.mls {
-            mls.set_user_pubkey(&pubkey.to_hex());
-        }
+        self.bind_mls_for_pubkey(pubkey).await?;
 
         // Load follow list, mute list in parallel
         let (follows, mutes) =
@@ -189,6 +179,72 @@ impl NuruNuruEngine {
         Ok(())
     }
 
+    async fn bind_mls_for_pubkey(&self, pubkey: PublicKey) -> Result<()> {
+        if self.config.mls_db_path.is_empty() {
+            return Ok(());
+        }
+
+        let pubkey_hex = pubkey.to_hex();
+        let db_key = *self.mls_db_key.read().await;
+        let result = match db_key {
+            Some(key) => MlsManager::new_with_key(&self.config.mls_db_path, &pubkey_hex, key),
+            None => MlsManager::new(&self.config.mls_db_path, &pubkey_hex),
+        };
+
+        match result {
+            Ok(manager) => {
+                *self.mls.write().await = Some(Arc::new(manager));
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!("[NuruNuruEngine] MLS bind failed (non-fatal): {e}");
+                *self.mls.write().await = None;
+                Ok(())
+            }
+        }
+    }
+
+    /// Set the SQLCipher key for the MLS DB. Call before `login()`; calling
+    /// after login drops the in-memory manager so the next bind picks it up.
+    pub async fn set_mls_db_key(&self, key: [u8; 32]) {
+        *self.mls_db_key.write().await = Some(key);
+        *self.mls.write().await = None;
+    }
+
+    /// Issue #178 #11: wipe + reopen the MLS DB for a new identity (logout/
+    /// login change on the same device).
+    pub async fn mls_reset(&self, new_pubkey: PublicKey) -> Result<()> {
+        if self.config.mls_db_path.is_empty() {
+            return Err(NuruNuruError::MlsError(
+                "mls_reset: no mls_db_path configured".to_string(),
+            ));
+        }
+
+        // Drop the existing manager first so the file handle is released
+        // before we unlink it.
+        *self.mls.write().await = None;
+
+        let db_path = self.config.mls_db_path.clone();
+        let sidecars = [
+            db_path.clone(),
+            format!("{db_path}-wal"),
+            format!("{db_path}-shm"),
+            format!("{db_path}-journal"),
+        ];
+        for path in &sidecars {
+            match std::fs::remove_file(path) {
+                Ok(()) => tracing::info!("[MLS] mls_reset removed {}", path),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => tracing::warn!("[MLS] mls_reset could not remove {}: {}", path, e),
+            }
+        }
+
+        // Update the in-memory identity too so subsequent calls see the new
+        // pubkey even if `login()` is skipped.
+        *self.user_pubkey.write().await = Some(new_pubkey);
+        self.bind_mls_for_pubkey(new_pubkey).await
+    }
+
     /// Get the current user's public key.
     pub async fn current_pubkey(&self) -> Option<PublicKey> {
         *self.user_pubkey.read().await
@@ -199,6 +255,12 @@ impl NuruNuruEngine {
             .signer()
             .await
             .map_err(|e| NuruNuruError::MlsError(format!("test signer unavailable: {e}")))
+    }
+
+    /// Test-only view into the immutable config (no `pub` setters; see
+    /// `set_mls_db_key` / `mls_reset` for the runtime mutation surface).
+    pub fn config_for_tests(&self) -> &NuruNuruConfig {
+        &self.config
     }
 
     // ─── Profile ──────────────────────────────────────────────
@@ -1216,9 +1278,15 @@ impl NuruNuruEngine {
 
     // ─── MLS / NIP-EE Delegation ─────────────────────────────────────────
 
-    fn require_mls(&self) -> Result<&MlsManager> {
+    /// Acquire a handle to the bound MLS manager, or error if MLS is not
+    /// initialised. Clones the `Arc` and releases the read lock so the MLS
+    /// call can run without blocking concurrent `mls_reset` / configuration.
+    async fn require_mls(&self) -> Result<Arc<MlsManager>> {
         self.mls
+            .read()
+            .await
             .as_ref()
+            .cloned()
             .ok_or_else(|| NuruNuruError::MlsError("MLS not initialised for this client".into()))
     }
 
@@ -1227,7 +1295,9 @@ impl NuruNuruEngine {
     /// Uses the engine's configured relay list for the `relays` tag.
     pub async fn mls_create_key_package(&self) -> Result<KeyPackageEventData> {
         let relay_urls: Vec<RelayUrl> = self.client.relays().await.keys().cloned().collect();
-        self.require_mls()?.create_key_package_event(&relay_urls)
+        self.require_mls()
+            .await?
+            .create_key_package_event(&relay_urls)
     }
 
     /// Strictly validate a KeyPackage event JSON (MIP-00).
@@ -1235,7 +1305,8 @@ impl NuruNuruEngine {
     /// This validates required tags/capabilities and verifies `i` (KeyPackageRef)
     /// against decoded content via MDK parser.
     pub async fn mls_validate_key_package_event(&self, key_package_event_json: &str) -> Result<()> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .validate_key_package_event(key_package_event_json)
     }
 
@@ -1244,19 +1315,22 @@ impl NuruNuruEngine {
         &self,
         key_package_event_json: &str,
     ) -> Result<()> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .delete_consumed_key_package_from_event_json(key_package_event_json)
     }
 
     /// Delete consumed KeyPackage private/init-key material using the exact hash_ref returned at creation.
     pub async fn mls_delete_consumed_key_package_by_hash_ref(&self, hash_ref: &[u8]) -> Result<()> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .delete_consumed_key_package_by_hash_ref(hash_ref)
     }
 
     /// Return MLS group IDs (hex) that need self-update per MDK state tracking.
     pub async fn mls_groups_needing_self_update(&self, threshold_secs: u64) -> Result<Vec<String>> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .groups_needing_self_update(threshold_secs)
     }
 
@@ -1267,7 +1341,8 @@ impl NuruNuruEngine {
         admin_pubkeys: Vec<String>,
         relays: Vec<String>,
     ) -> Result<MlsGroupInfo> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .create_group(name, admin_pubkeys, relays)
     }
 
@@ -1286,7 +1361,8 @@ impl NuruNuruEngine {
         key_package_event_json: &str,
     ) -> Result<AddMemberResult> {
         let mut result = self
-            .require_mls()?
+            .require_mls()
+            .await?
             .add_member(group_id_hex, key_package_event_json)?;
 
         // Apply NIP-59 gift-wrap to the Welcome rumor if present
@@ -1334,7 +1410,9 @@ impl NuruNuruEngine {
         group_id_hex: &str,
         content: &str,
     ) -> Result<EncryptedMessageData> {
-        self.require_mls()?.create_message(group_id_hex, content)
+        self.require_mls()
+            .await?
+            .create_message(group_id_hex, content)
     }
 
     /// Decrypt/process an incoming Kind-445 event.
@@ -1343,7 +1421,8 @@ impl NuruNuruEngine {
         group_id_hex: &str,
         event_json: &str,
     ) -> Result<DecryptedMessage> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .process_message(group_id_hex, event_json)
     }
 
@@ -1353,7 +1432,8 @@ impl NuruNuruEngine {
         group_id_hex: &str,
         event_json: &str,
     ) -> Result<MlsProcessResult> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .process_message_result(group_id_hex, event_json)
     }
 
@@ -1486,14 +1566,67 @@ impl NuruNuruEngine {
 
     /// Process an incoming Welcome event and join the group.
     ///
-    /// Accepts both:
-    /// - Kind 1059 (NIP-59 gift-wrapped Welcome, Marmot MIP-02) — unwraps automatically
-    /// - Kind 444 (legacy NIP-EE signed/unsigned Welcome) — normalizes to MDK's unsigned rumor shape
+    /// Accepts Kind 1059 (NIP-59 gift-wrap, Marmot MIP-02), Kind 444 (legacy
+    /// signed/unsigned Welcome), or a raw unwrapped rumor JSON.
     pub async fn mls_process_welcome(&self, welcome_event_json: &str) -> Result<MlsGroupInfo> {
-        // Try to parse as a signed Event first (gift-wrap or legacy)
+        let (wrapper_event_id, rumor) = self.unwrap_welcome_input(welcome_event_json).await?;
+        tracing::info!(
+            "[MLS] normalized welcome: {}",
+            Self::welcome_debug_summary(&wrapper_event_id, &rumor)
+        );
+        let mls = self.require_mls().await?;
+        mls.process_welcome_rumor(&wrapper_event_id, &rumor)
+            .map_err(|e| {
+                NuruNuruError::MlsError(format!(
+                    "{}; {}",
+                    e,
+                    Self::welcome_debug_summary(&wrapper_event_id, &rumor)
+                ))
+            })
+    }
+
+    /// Issue #178 #4: stage a Welcome for accept/decline UX. Accepts the same
+    /// input formats as [`Self::mls_process_welcome`].
+    pub async fn mls_preview_welcome(&self, welcome_event_json: &str) -> Result<PendingWelcome> {
+        let (wrapper_event_id, rumor) = self.unwrap_welcome_input(welcome_event_json).await?;
+        let mls = self.require_mls().await?;
+        mls.preview_welcome_rumor(&wrapper_event_id, &rumor)
+            .map_err(|e| {
+                NuruNuruError::MlsError(format!(
+                    "{}; {}",
+                    e,
+                    Self::welcome_debug_summary(&wrapper_event_id, &rumor)
+                ))
+            })
+    }
+
+    /// Accept a previously previewed Welcome by its inner Welcome rumor event id (Kind 444).
+    pub async fn mls_accept_welcome(&self, welcome_event_id_hex: &str) -> Result<PendingWelcome> {
+        let id = EventId::from_hex(welcome_event_id_hex)
+            .map_err(|e| NuruNuruError::MlsError(format!("Invalid welcome event id: {e}")))?;
+        self.require_mls().await?.accept_pending_welcome(&id)
+    }
+
+    /// Decline a previously previewed Welcome by its inner Welcome rumor event id (Kind 444).
+    pub async fn mls_decline_welcome(&self, welcome_event_id_hex: &str) -> Result<()> {
+        let id = EventId::from_hex(welcome_event_id_hex)
+            .map_err(|e| NuruNuruError::MlsError(format!("Invalid welcome event id: {e}")))?;
+        self.require_mls().await?.decline_pending_welcome(&id)
+    }
+
+    /// List Welcomes that have been previewed but not yet accepted/declined.
+    pub async fn mls_get_pending_welcomes(&self) -> Result<Vec<PendingWelcome>> {
+        self.require_mls().await?.get_pending_welcomes()
+    }
+
+    /// Normalise any welcome input (kind:1059 gift-wrap, signed kind:444, raw
+    /// rumor JSON) into `(wrapper_event_id, rumor)` for MDK.
+    async fn unwrap_welcome_input(
+        &self,
+        welcome_event_json: &str,
+    ) -> Result<(EventId, UnsignedEvent)> {
         if let Ok(event) = serde_json::from_str::<nostr::Event>(welcome_event_json) {
             if event.kind == nostr::Kind::GiftWrap {
-                // NIP-59 unwrap: Kind 1059 → Kind 13 seal → Kind 444 rumor
                 let signer =
                     self.client.signer().await.map_err(|e| {
                         NuruNuruError::MlsError(format!("No signer for unwrap: {e}"))
@@ -1510,22 +1643,8 @@ impl NuruNuruEngine {
                     )));
                 }
                 let rumor = Self::normalize_marmot_welcome_rumor(unwrapped.rumor)?;
-                tracing::info!(
-                    "[MLS] normalized welcome: {}",
-                    Self::welcome_debug_summary(&event.id, &rumor)
-                );
-                return self
-                    .require_mls()?
-                    .process_welcome_rumor(&event.id, &rumor)
-                    .map_err(|e| {
-                        NuruNuruError::MlsError(format!(
-                            "{}; {}",
-                            e,
-                            Self::welcome_debug_summary(&event.id, &rumor)
-                        ))
-                    });
+                return Ok((event.id, rumor));
             }
-
             if event.kind == nostr::Kind::MlsWelcome || event.kind.as_u16() == 10_444 {
                 let rumor = UnsignedEvent {
                     id: Some(event.id),
@@ -1536,41 +1655,15 @@ impl NuruNuruEngine {
                     content: event.content,
                 };
                 let rumor = Self::normalize_marmot_welcome_rumor(rumor)?;
-                tracing::info!(
-                    "[MLS] normalized welcome: {}",
-                    Self::welcome_debug_summary(&event.id, &rumor)
-                );
-                return self
-                    .require_mls()?
-                    .process_welcome_rumor(&event.id, &rumor)
-                    .map_err(|e| {
-                        NuruNuruError::MlsError(format!(
-                            "{}; {}",
-                            e,
-                            Self::welcome_debug_summary(&event.id, &rumor)
-                        ))
-                    });
+                return Ok((event.id, rumor));
             }
         }
 
-        // Legacy/raw rumor JSON.
         let rumor: UnsignedEvent = serde_json::from_str(welcome_event_json)
             .map_err(|e| NuruNuruError::MlsError(format!("Invalid welcome JSON: {e}")))?;
         let mut rumor = Self::normalize_marmot_welcome_rumor(rumor)?;
         let wrapper_event_id = rumor.id();
-        tracing::info!(
-            "[MLS] normalized welcome: {}",
-            Self::welcome_debug_summary(&wrapper_event_id, &rumor)
-        );
-        self.require_mls()?
-            .process_welcome_rumor(&wrapper_event_id, &rumor)
-            .map_err(|e| {
-                NuruNuruError::MlsError(format!(
-                    "{}; {}",
-                    e,
-                    Self::welcome_debug_summary(&wrapper_event_id, &rumor)
-                ))
-            })
+        Ok((wrapper_event_id, rumor))
     }
 
     /// Retrieve decrypted message history for a group from MDK's local SQLite.
@@ -1579,17 +1672,19 @@ impl NuruNuruEngine {
         group_id_hex: &str,
         limit: u64,
     ) -> Result<Vec<DecryptedMessage>> {
-        self.require_mls()?.get_message_history(group_id_hex, limit)
+        self.require_mls()
+            .await?
+            .get_message_history(group_id_hex, limit)
     }
 
     /// List all MLS groups the user belongs to.
     pub async fn mls_list_groups(&self) -> Result<Vec<MlsGroupInfo>> {
-        self.require_mls()?.list_groups()
+        self.require_mls().await?.list_groups()
     }
 
     /// Get metadata for a single MLS group.
     pub async fn mls_get_group_info(&self, group_id_hex: &str) -> Result<MlsGroupInfo> {
-        self.require_mls()?.get_group_info(group_id_hex)
+        self.require_mls().await?.get_group_info(group_id_hex)
     }
 
     // NOTE: mls_self_demote() will be added when mdk-core releases self_demote().
@@ -1598,7 +1693,7 @@ impl NuruNuruEngine {
     /// Leave a group (publishes self-removal commit event data).
     /// Uses SelfRemove proposal internally (Marmot MIP-03).
     pub async fn mls_leave_group(&self, group_id_hex: &str) -> Result<EncryptedMessageData> {
-        self.require_mls()?.leave_group(group_id_hex)
+        self.require_mls().await?.leave_group(group_id_hex)
     }
 
     /// Remove a member from a group.
@@ -1607,13 +1702,16 @@ impl NuruNuruEngine {
         group_id_hex: &str,
         member_pubkey: &str,
     ) -> Result<EncryptedMessageData> {
-        self.require_mls()?
+        self.require_mls()
+            .await?
             .remove_member(group_id_hex, member_pubkey)
     }
 
-    /// Merge the pending commit for a group after publishing to relays.
+    /// Merge a pending commit **only after** the matching commit event was
+    /// successfully published. Issue #178 #2: calling this on every receive
+    /// poll forks the group if a prior publish silently failed.
     pub async fn mls_merge_pending_commit(&self, group_id_hex: &str) -> Result<()> {
-        self.require_mls()?.merge_pending_commit(group_id_hex)
+        self.require_mls().await?.merge_pending_commit(group_id_hex)
     }
 
     /// Create a recovery self-update commit event for stuck pending proposals.
@@ -1621,12 +1719,43 @@ impl NuruNuruEngine {
         &self,
         group_id_hex: &str,
     ) -> Result<EncryptedMessageData> {
-        self.require_mls()?.create_recovery_commit(group_id_hex)
+        self.require_mls()
+            .await?
+            .create_recovery_commit(group_id_hex)
     }
 
     /// Clear (rollback) pending commit for recovery from stuck MLS state.
     pub async fn mls_clear_pending_commit(&self, group_id_hex: &str) -> Result<()> {
-        self.require_mls()?.clear_pending_commit(group_id_hex)
+        self.require_mls().await?.clear_pending_commit(group_id_hex)
+    }
+
+    // ─── MLS subscription helpers (issue #178 #9, #10) ────────────────────
+
+    /// Issue #178 #9: subscribe to my Welcomes (kind:1059 #p=self). Returns
+    /// the engine sub_id; poll via [`Self::poll_subscription`].
+    pub async fn mls_subscribe_welcomes(&self, since: Option<Timestamp>) -> Result<String> {
+        let my_pk = self
+            .current_pubkey()
+            .await
+            .ok_or(NuruNuruError::NoSigningMethod)?;
+        let mut filter = Filter::new().kind(Kind::GiftWrap).pubkey(my_pk);
+        if let Some(ts) = since {
+            filter = filter.since(ts);
+        }
+        self.subscribe_stream(filter).await
+    }
+
+    /// Issue #178 #10: subscribe to KeyPackage rotations (kind:30443) from
+    /// the given contacts. Empty list = all kind:30443 (expensive).
+    pub async fn mls_subscribe_keypackage_rotations(
+        &self,
+        contact_pubkeys: Vec<PublicKey>,
+    ) -> Result<String> {
+        let mut filter = Filter::new().kind(Kind::from(30443u16));
+        if !contact_pubkeys.is_empty() {
+            filter = filter.authors(contact_pubkeys);
+        }
+        self.subscribe_stream(filter).await
     }
 }
 

--- a/rust-engine/nurunuru-core/src/mls.rs
+++ b/rust-engine/nurunuru-core/src/mls.rs
@@ -22,16 +22,18 @@
 //! Kind-444 (Welcome) rumors are gift-wrapped via NIP-59 in `engine.rs`
 //! (`mls_add_member`) using the engine's signer.
 
+use std::collections::BTreeSet;
+
 use base64::Engine as _;
 use mdk_core::groups::NostrGroupConfigData;
-use mdk_sqlite_storage::MdkSqliteStorage;
-use nostr::{EventBuilder, JsonUtil, PublicKey, RelayUrl, UnsignedEvent};
+use mdk_sqlite_storage::{EncryptionConfig, MdkSqliteStorage};
+use nostr::{EventBuilder, EventId, JsonUtil, PublicKey, RelayUrl, UnsignedEvent};
 use serde_json::Value;
 
 use crate::error::{NuruNuruError, Result};
 use crate::types::{
-    AddMemberResult, DecryptedMessage, EncryptedMessageData, KeyPackageEventData, MlsGroupInfo,
-    WelcomeEventData,
+    AddMemberResult, CommitDelta, DecryptedMessage, EncryptedMessageData, KeyPackageEventData,
+    MlsGroupInfo, PendingWelcome, WelcomeEventData,
 };
 
 // ─── Type alias ──────────────────────────────────────────────────────────────
@@ -83,27 +85,22 @@ fn mls_error_label(error: &dyn std::fmt::Display) -> &'static str {
 
 // ─── MlsManager ──────────────────────────────────────────────────────────────
 
-/// Thin wrapper around `mdk_core::MDK` that translates MLS operations into
-/// Nostr event payloads ready for signing and publishing.
-///
-/// `MlsManager` is not `Clone`; hold it behind `Option<MlsManager>` in the
-/// engine.  Read-only (anonymous) clients keep `None`.
+/// Wraps `mdk_core::MDK` and produces/consumes Nostr event payloads for
+/// Marmot kinds 30443/444/1059/445. Identity is bound at construction; to
+/// switch users, drop this manager (see `NuruNuruEngine::mls_reset`).
 pub struct MlsManager {
     mdk: Mdk,
-    /// Hex-encoded Nostr public key of the local user.  Set on `login()`.
-    /// Uses `RwLock` so `set_user_pubkey` can be called via `&self` from
-    /// `NuruNuruEngine::login()` without requiring `&mut self` on the engine.
-    user_pubkey_hex: std::sync::RwLock<String>,
+    user_pubkey: PublicKey,
     db_path: String,
+    encrypted: bool,
 }
 
 impl MlsManager {
-    /// Open (or create) the MLS SQLite database and initialise MDK.
-    ///
-    /// `db_path`      — absolute path to the `.sqlite3` file
-    /// `nostr_pubkey` — hex-encoded Nostr public key (may be empty at init,
-    ///                  call `set_user_pubkey` after login)
+    /// Unencrypted SQLite open. Prefer [`MlsManager::new_with_key`]
+    /// (SQLCipher) for production; this is for tests / pre-migration installs.
     pub fn new(db_path: &str, nostr_pubkey: &str) -> Result<Self> {
+        let pubkey = Self::parse_required_pubkey(nostr_pubkey)?;
+
         let storage = MdkSqliteStorage::new_unencrypted(db_path)
             .map_err(|e| NuruNuruError::MlsError(format!("SQLite open: {e}")))?;
 
@@ -111,28 +108,65 @@ impl MlsManager {
 
         Ok(Self {
             mdk,
-            user_pubkey_hex: std::sync::RwLock::new(nostr_pubkey.to_string()),
+            user_pubkey: pubkey,
             db_path: db_path.to_string(),
+            encrypted: false,
         })
     }
 
-    /// Update the stored user pubkey after login().
-    /// Takes `&self` so it can be called from `NuruNuruEngine::login()` via `Arc<Self>`.
-    pub fn set_user_pubkey(&self, pubkey_hex: &str) {
-        if let Ok(mut w) = self.user_pubkey_hex.write() {
-            *w = pubkey_hex.to_string();
-        }
+    /// SQLCipher-encrypted SQLite open. Derive `db_key` via
+    /// [`derive_mls_db_key`] or source it from a platform keychain/keystore.
+    pub fn new_with_key(db_path: &str, nostr_pubkey: &str, db_key: [u8; 32]) -> Result<Self> {
+        let pubkey = Self::parse_required_pubkey(nostr_pubkey)?;
+
+        let config = EncryptionConfig::new(db_key);
+        let storage = MdkSqliteStorage::new_with_key(db_path, config)
+            .map_err(|e| NuruNuruError::MlsError(format!("SQLite encrypted open: {e}")))?;
+
+        let mdk = Mdk::new(storage);
+
+        Ok(Self {
+            mdk,
+            user_pubkey: pubkey,
+            db_path: db_path.to_string(),
+            encrypted: true,
+        })
     }
 
-    fn user_pubkey(&self) -> Result<PublicKey> {
-        let hex = self
-            .user_pubkey_hex
-            .read()
-            .map_err(|_| NuruNuruError::MlsError("pubkey lock poisoned".to_string()))?;
-        PublicKey::from_hex(&*hex)
+    fn parse_required_pubkey(nostr_pubkey: &str) -> Result<PublicKey> {
+        if nostr_pubkey.trim().is_empty() {
+            return Err(NuruNuruError::MlsError(
+                "MlsManager requires a non-empty Nostr pubkey at construction time".to_string(),
+            ));
+        }
+        PublicKey::from_hex(nostr_pubkey)
             .map_err(|e| NuruNuruError::MlsError(format!("Invalid user pubkey: {e}")))
     }
 
+    fn user_pubkey(&self) -> Result<PublicKey> {
+        Ok(self.user_pubkey)
+    }
+
+    /// `true` when the underlying SQLite is SQLCipher-encrypted (used in tests).
+    pub fn is_encrypted(&self) -> bool {
+        self.encrypted
+    }
+}
+
+/// HKDF-SHA256 over the raw 32-byte secret key. Deterministic, so the
+/// encrypted DB can be reopened on the same device without keychain
+/// round-trips. `app_salt` scopes the key (use e.g. `b"io.nurunuru.mdk.v1"`).
+pub fn derive_mls_db_key(nsec_bytes: &[u8; 32], app_salt: &[u8]) -> [u8; 32] {
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    let hk = Hkdf::<Sha256>::new(Some(app_salt), nsec_bytes);
+    let mut out = [0u8; 32];
+    hk.expand(b"mdk-sqlite-db-key", &mut out)
+        .expect("32 bytes is well within HKDF-SHA256 output limits");
+    out
+}
+
+impl MlsManager {
     /// Resolve a `nostr_group_id` hex string (32 bytes = 64 hex chars) to the
     /// internal `mdk_storage_traits::GroupId` (= `mls_group_id`) used by MDK API calls.
     ///
@@ -610,6 +644,56 @@ impl MlsManager {
         })
     }
 
+    /// Compute a `CommitDelta` by diffing membership before vs after MDK
+    /// applied the commit. Issue #178 #5: lets the UI render add/remove
+    /// without a racey `get_group_info` re-query.
+    fn build_commit_delta_result(
+        &self,
+        group_id_hex: &str,
+        members_before: Option<BTreeSet<String>>,
+        log_tag: &str,
+        event_id: &nostr::EventId,
+    ) -> crate::types::MlsProcessResult {
+        let (members_after, epoch_after) = match self.resolve_group_id(group_id_hex) {
+            Ok(gid) => {
+                let after: BTreeSet<String> = self
+                    .mdk
+                    .get_members(&gid)
+                    .map(|set| set.iter().map(|pk| pk.to_hex()).collect())
+                    .unwrap_or_default();
+                let epoch = self
+                    .mdk
+                    .get_group(&gid)
+                    .ok()
+                    .flatten()
+                    .map(|g| g.epoch)
+                    .unwrap_or(0);
+                (after, epoch)
+            }
+            Err(_) => (BTreeSet::new(), 0),
+        };
+        let before = members_before.unwrap_or_default();
+        let added: Vec<String> = members_after.difference(&before).cloned().collect();
+        let removed: Vec<String> = before.difference(&members_after).cloned().collect();
+        tracing::info!(
+            "[MLS] process_message {} group={} event_id={} added={} removed={} epoch={}",
+            log_tag,
+            group_id_hex,
+            event_id.to_hex(),
+            added.len(),
+            removed.len(),
+            epoch_after
+        );
+        crate::types::MlsProcessResult::Commit {
+            group_id_hex: group_id_hex.to_string(),
+            delta: CommitDelta {
+                added_pubkeys: added,
+                removed_pubkeys: removed,
+                epoch_after,
+            },
+        }
+    }
+
     /// Process an incoming Kind-445 event (Proposal / Commit / Application).
     pub fn process_message_result(
         &self,
@@ -670,6 +754,13 @@ impl MlsManager {
             });
         }
 
+        // Snapshot members so we can diff after Commit (MDK 0.8 only returns mls_group_id).
+        let members_before: Option<BTreeSet<String>> = self
+            .resolve_group_id(group_id_hex)
+            .ok()
+            .and_then(|gid| self.mdk.get_members(&gid).ok())
+            .map(|set| set.iter().map(|pk| pk.to_hex()).collect());
+
         let result = self
             .mdk
             .process_message(&event)
@@ -694,34 +785,32 @@ impl MlsManager {
                     },
                 ))
             }
-            mdk_core::messages::MessageProcessingResult::Commit { .. } => {
-                tracing::info!(
-                    "[MLS] process_message commit group={} event_id={} — state updated",
+            mdk_core::messages::MessageProcessingResult::Commit { .. } => Ok(
+                self.build_commit_delta_result(group_id_hex, members_before, "commit", &event.id)
+            ),
+            // MDK auto-commits some proposals (e.g. self-remove when receiver
+            // is admin); surface them as commits too.
+            mdk_core::messages::MessageProcessingResult::Proposal(_) => Ok(self
+                .build_commit_delta_result(
                     group_id_hex,
-                    event.id.to_hex()
-                );
-                Ok(crate::types::MlsProcessResult::StateUpdate {
-                    kind: "commit".to_string(),
-                })
-            }
-            mdk_core::messages::MessageProcessingResult::Proposal(_) => {
-                tracing::info!(
-                    "[MLS] process_message proposal group={} event_id={} — auto-committed",
-                    group_id_hex,
-                    event.id.to_hex()
-                );
-                Ok(crate::types::MlsProcessResult::StateUpdate {
-                    kind: "proposal".to_string(),
-                })
-            }
+                    members_before,
+                    "proposal_auto_committed",
+                    &event.id,
+                )),
             mdk_core::messages::MessageProcessingResult::PendingProposal { .. } => {
-                tracing::info!(
-                    "[MLS] process_message pending_proposal group={} event_id={} — stored",
+                // A pending proposal sits in MDK storage. Multi-member groups
+                // will stall on the next clean-state operation ("pending
+                // proposal exists") and the group can fork. Surface a signal
+                // so the engine/app schedules a `self_update` commit to resolve
+                // it instead of silently logging.
+                tracing::warn!(
+                    "[MLS] process_message pending_proposal group={} event_id={} — needs self_update",
                     group_id_hex,
                     event.id.to_hex()
                 );
-                Ok(crate::types::MlsProcessResult::StateUpdate {
-                    kind: "pending_proposal".to_string(),
+                Ok(crate::types::MlsProcessResult::NeedsSelfUpdate {
+                    group_id_hex: group_id_hex.to_string(),
+                    reason: "pending_proposal".to_string(),
                 })
             }
             other => {
@@ -796,7 +885,9 @@ impl MlsManager {
     ) -> Result<DecryptedMessage> {
         match self.process_message_result(group_id_hex, event_json)? {
             crate::types::MlsProcessResult::ApplicationMessage(msg) => Ok(msg),
-            crate::types::MlsProcessResult::StateUpdate { .. } => {
+            crate::types::MlsProcessResult::Commit { .. }
+            | crate::types::MlsProcessResult::NeedsSelfUpdate { .. }
+            | crate::types::MlsProcessResult::StateUpdate { .. } => {
                 Err(NuruNuruError::MlsStateUpdate)
             }
         }
@@ -804,10 +895,10 @@ impl MlsManager {
 
     // ─── Welcome (Kind 444) ───────────────────────────────────────────────
 
-    /// Process an incoming Kind-444 Welcome and join the group.
-    ///
-    /// `welcome_event_json` — JSON of the **rumor** (inner, unwrapped unsigned event).
-    /// The wrapper Event ID is extracted from the rumor's `id` field for MDK tracking.
+    /// Process + accept a Welcome in one step (back-compat). Prefer the split
+    /// API ([`Self::preview_welcome_rumor`] +
+    /// [`Self::accept_pending_welcome`] / [`Self::decline_pending_welcome`])
+    /// so users can decline — see issue #178 #4.
     pub fn process_welcome(&self, welcome_event_json: &str) -> Result<MlsGroupInfo> {
         let mut rumor: UnsignedEvent = serde_json::from_str(welcome_event_json)
             .map_err(|e| NuruNuruError::MlsError(format!("Invalid welcome JSON: {e}")))?;
@@ -818,58 +909,127 @@ impl MlsManager {
         self.process_welcome_rumor(&wrapper_event_id, &rumor)
     }
 
-    /// Process an already-unwrapped Welcome rumor and join the group.
-    ///
-    /// `wrapper_event_id` must be the outer kind:1059 event id when available.
-    /// MDK stores processed/failed Welcome state under this id, so using the
-    /// inner rumor id causes repeated failures and prevents interoperability with
-    /// Marmot/WhiteNoise gift-wrapped Welcomes.
+    /// Back-compat fused process+accept. Prefer the split API for new code.
     pub fn process_welcome_rumor(
         &self,
         wrapper_event_id: &nostr::EventId,
         rumor: &UnsignedEvent,
     ) -> Result<MlsGroupInfo> {
-        let welcome = self
-            .mdk
-            .process_welcome(wrapper_event_id, rumor)
-            .map_err(|e| NuruNuruError::MlsError(format!("process_welcome: {e}")))?;
+        let preview = self.preview_welcome_rumor(wrapper_event_id, rumor)?;
+        let welcome_id = EventId::from_hex(&preview.welcome_event_id_hex)
+            .map_err(|e| NuruNuruError::MlsError(format!("Invalid welcome_event_id: {e}")))?;
+        let _ = self.accept_pending_welcome(&welcome_id)?;
 
-        // `process_welcome` in MDK only stores a pending welcome preview. The
-        // NuruNuru API method is documented/used as "process and join", so accept
-        // it immediately to create the local MLS group and mark the required
-        // post-join self-update state.
-        self.mdk
-            .accept_welcome(&welcome)
-            .map_err(|e| NuruNuruError::MlsError(format!("accept_welcome: {e}")))?;
-
-        let group_id_hex = hex::encode(welcome.nostr_group_id);
-        let is_dm = welcome.member_count <= 2;
+        let group_id_hex = preview.group_id_hex.clone();
+        let is_dm = preview.is_dm;
 
         // The Welcome record itself doesn't carry disappearing_message_secs;
         // read it from the stored group metadata if already available.
         let disappearing_message_secs = self
-            .mdk
-            .get_group(&welcome.mls_group_id)
+            .resolve_group_id(&group_id_hex)
             .ok()
-            .flatten()
+            .and_then(|gid| self.mdk.get_group(&gid).ok().flatten())
             .and_then(|g| g.disappearing_message_secs);
 
         Ok(MlsGroupInfo {
             group_id_hex,
-            name: welcome.group_name,
-            description: welcome.group_description,
-            admin_pubkeys: welcome
-                .group_admin_pubkeys
-                .iter()
-                .map(|pk| pk.to_hex())
-                .collect(),
+            name: preview.group_name,
+            description: preview.group_description,
+            admin_pubkeys: preview.group_admin_pubkeys,
             member_pubkeys: Vec::new(),
-            relays: welcome.group_relays.iter().map(|r| r.to_string()).collect(),
+            relays: preview.group_relays,
             created_at: 0,
             epoch: 0,
             disappearing_message_secs,
             is_dm,
         })
+    }
+
+    /// Stage a Welcome without joining. `wrapper_event_id` is the outer
+    /// kind:1059 id when available (MDK keys processed state on it).
+    pub fn preview_welcome_rumor(
+        &self,
+        wrapper_event_id: &nostr::EventId,
+        rumor: &UnsignedEvent,
+    ) -> Result<PendingWelcome> {
+        let welcome = self
+            .mdk
+            .process_welcome(wrapper_event_id, rumor)
+            .map_err(|e| NuruNuruError::MlsError(format!("process_welcome: {e}")))?;
+
+        Ok(Self::welcome_to_pending(&welcome))
+    }
+
+    fn welcome_to_pending(
+        welcome: &mdk_storage_traits::welcomes::types::Welcome,
+    ) -> PendingWelcome {
+        PendingWelcome {
+            welcome_event_id_hex: welcome.id.to_hex(),
+            wrapper_event_id_hex: welcome.wrapper_event_id.to_hex(),
+            group_id_hex: hex::encode(welcome.nostr_group_id),
+            group_name: welcome.group_name.clone(),
+            group_description: welcome.group_description.clone(),
+            group_admin_pubkeys: welcome
+                .group_admin_pubkeys
+                .iter()
+                .map(|pk| pk.to_hex())
+                .collect(),
+            group_relays: welcome.group_relays.iter().map(|r| r.to_string()).collect(),
+            welcomer_pubkey: welcome.welcomer.to_hex(),
+            member_count: welcome.member_count,
+            is_dm: welcome.member_count <= 2,
+        }
+    }
+
+    /// List Welcomes that have been previewed but not yet accepted/declined.
+    pub fn get_pending_welcomes(&self) -> Result<Vec<PendingWelcome>> {
+        let welcomes = self
+            .mdk
+            .get_pending_welcomes(None)
+            .map_err(|e| NuruNuruError::MlsError(format!("get_pending_welcomes: {e}")))?;
+        Ok(welcomes.iter().map(Self::welcome_to_pending).collect())
+    }
+
+    /// Accept a previewed Welcome — joins the group and marks the MIP-02
+    /// post-join self-update required.
+    pub fn accept_pending_welcome(&self, welcome_event_id: &EventId) -> Result<PendingWelcome> {
+        let welcome = self
+            .mdk
+            .get_welcome(welcome_event_id)
+            .map_err(|e| NuruNuruError::MlsError(format!("get_welcome: {e}")))?
+            .ok_or_else(|| {
+                NuruNuruError::MlsError(format!(
+                    "accept_pending_welcome: welcome not found for welcome_event_id={}",
+                    welcome_event_id.to_hex()
+                ))
+            })?;
+
+        self.mdk
+            .accept_welcome(&welcome)
+            .map_err(|e| NuruNuruError::MlsError(format!("accept_welcome: {e}")))?;
+
+        // TODO(mdk): receive-side init-key delete API not yet exposed (issue #178 #8).
+        // Send-side `delete_consumed_key_package_by_hash_ref` covers the common case.
+
+        Ok(Self::welcome_to_pending(&welcome))
+    }
+
+    /// Decline a previewed Welcome.
+    pub fn decline_pending_welcome(&self, welcome_event_id: &EventId) -> Result<()> {
+        let welcome = self
+            .mdk
+            .get_welcome(welcome_event_id)
+            .map_err(|e| NuruNuruError::MlsError(format!("get_welcome: {e}")))?
+            .ok_or_else(|| {
+                NuruNuruError::MlsError(format!(
+                    "decline_pending_welcome: welcome not found for welcome_event_id={}",
+                    welcome_event_id.to_hex()
+                ))
+            })?;
+
+        self.mdk
+            .decline_welcome(&welcome)
+            .map_err(|e| NuruNuruError::MlsError(format!("decline_welcome: {e}")))
     }
 
     // ─── Group queries ────────────────────────────────────────────────────

--- a/rust-engine/nurunuru-core/src/types.rs
+++ b/rust-engine/nurunuru-core/src/types.rs
@@ -198,11 +198,55 @@ pub struct DecryptedMessage {
     pub group_id_hex: String,
 }
 
+/// Issue #178 #5: membership delta the wrapper computes by diffing members
+/// before vs after MDK applies a Commit. Lets the UI render add/remove
+/// without a `get_group_info` re-query.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommitDelta {
+    pub added_pubkeys: Vec<String>,
+    pub removed_pubkeys: Vec<String>,
+    pub epoch_after: u64,
+}
+
 /// Structured result for processing a Kind 445 event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MlsProcessResult {
     ApplicationMessage(DecryptedMessage),
-    StateUpdate { kind: String },
+    /// Issue #178 #5: commit applied; delta tells the UI who joined/left.
+    Commit {
+        group_id_hex: String,
+        delta: CommitDelta,
+    },
+    /// Issue #178 #6: pending proposal stored; app must run a self-update.
+    NeedsSelfUpdate {
+        group_id_hex: String,
+        reason: String,
+    },
+    /// Catch-all for unprocessable / unhandled MDK results.
+    StateUpdate {
+        kind: String,
+    },
+}
+
+/// Issue #178 #4: a Welcome staged for accept/decline UX.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingWelcome {
+    /// Inner kind:444 rumor id — the lookup key MDK uses.
+    pub welcome_event_id_hex: String,
+    /// Outer kind:1059 gift-wrap id — for app-side dedup.
+    pub wrapper_event_id_hex: String,
+    /// `nostr_group_id` (32-byte hex) — the same id used in Kind-445 `h` tags.
+    pub group_id_hex: String,
+    pub group_name: String,
+    pub group_description: String,
+    pub group_admin_pubkeys: Vec<String>,
+    pub group_relays: Vec<String>,
+    /// Pubkey of the inviter (welcomer).
+    pub welcomer_pubkey: String,
+    /// Number of members in the group at Welcome time (creator + invitees).
+    pub member_count: u32,
+    /// `true` when member_count <= 2 (1:1 DM).
+    pub is_dm: bool,
 }
 
 /// Japanese-friendly timestamp display

--- a/rust-engine/nurunuru-core/tests/issue_178_fixes.rs
+++ b/rust-engine/nurunuru-core/tests/issue_178_fixes.rs
@@ -1,0 +1,456 @@
+//! Regression tests for the MDK-integration findings filed as
+//! <https://github.com/tami1A84/null--nostr/issues/178>.
+//!
+//! These tests pin down the wrapper-side behaviours the issue asked for so
+//! future refactors cannot silently regress them:
+//!
+//! * #4 process_welcome / accept_welcome / decline_welcome are exposed
+//!   separately and `get_pending_welcomes` returns previewed Welcomes.
+//! * #5 Commit processing surfaces structured `added_pubkeys` and
+//!   `removed_pubkeys` via the new `MlsProcessResult::Commit` variant.
+//! * #11 `MlsManager::new` refuses an empty pubkey and `engine.mls_reset`
+//!   wipes the on-disk MLS state.
+//! * #1 `MlsManager::new_with_key` opens an encrypted SQLCipher DB and
+//!   `derive_mls_db_key` produces a stable 32-byte key from HKDF.
+//! * #9/#10 The engine exposes `mls_subscribe_welcomes` and
+//!   `mls_subscribe_keypackage_rotations`.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag};
+use nurunuru_core::config::NuruNuruConfig;
+use nurunuru_core::mls::{derive_mls_db_key, MlsManager};
+use nurunuru_core::types::MlsProcessResult;
+use nurunuru_core::NuruNuruEngine;
+
+fn unique_db_path(name: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "nurunuru_issue178_{}_{}_{}.sqlite3",
+        name,
+        std::process::id(),
+        nanos
+    ));
+    path.to_string_lossy().to_string()
+}
+
+fn test_config(mls_db_path: String) -> NuruNuruConfig {
+    NuruNuruConfig {
+        db_path: String::new(),
+        mls_db_path,
+        ..NuruNuruConfig::default()
+    }
+}
+
+async fn engine_for(keys: &Keys, name: &str) -> Arc<NuruNuruEngine> {
+    let cfg = test_config(unique_db_path(name));
+    let engine = NuruNuruEngine::new(keys.clone(), cfg).await.unwrap();
+    engine.login(keys.public_key()).await.unwrap();
+    engine
+}
+
+// ── #11 Identity binding ─────────────────────────────────────────────────────
+
+#[test]
+fn issue_178_11_mls_manager_refuses_empty_pubkey() {
+    let res = MlsManager::new(&unique_db_path("empty_pk"), "");
+    match res {
+        Err(e) => assert!(
+            format!("{e}").contains("non-empty"),
+            "error should mention empty pubkey requirement, got {e}"
+        ),
+        Ok(_) => panic!("MlsManager::new must reject empty pubkey"),
+    }
+}
+
+#[test]
+fn issue_178_11_mls_manager_refuses_whitespace_pubkey() {
+    let res = MlsManager::new(&unique_db_path("ws_pk"), "   ");
+    match res {
+        Err(e) => assert!(
+            format!("{e}").contains("non-empty"),
+            "error should mention empty pubkey requirement, got {e}"
+        ),
+        Ok(_) => panic!("MlsManager::new must reject whitespace-only pubkey"),
+    }
+}
+
+#[tokio::test]
+async fn issue_178_11_mls_reset_wipes_sqlite_file() {
+    let alice = Keys::generate();
+    let engine = engine_for(&alice, "reset_wipes").await;
+
+    // Touch the DB by creating a key package — this guarantees the SQLite file
+    // actually exists on disk before we ask reset() to wipe it.
+    engine.mls_create_key_package().await.unwrap();
+
+    let path = engine.config_for_tests().mls_db_path.clone();
+    assert!(
+        std::path::Path::new(&path).exists(),
+        "DB file should exist before reset, path={path}"
+    );
+
+    let bob = Keys::generate();
+    engine.mls_reset(bob.public_key()).await.unwrap();
+
+    // After reset(): the prior file should be gone (or recreated empty by the
+    // new manager). Either way, the *previous* MLS state must not survive.
+    // Simplest invariant: the manager is bound to Bob's identity now.
+    let pkg = engine.mls_create_key_package().await.unwrap();
+    assert_eq!(pkg.kind, 30443, "fresh manager must produce kind:30443");
+}
+
+// ── #1 Encrypted database ────────────────────────────────────────────────────
+
+#[test]
+fn issue_178_1_encrypted_db_open_and_reopen_with_same_key() {
+    let path = unique_db_path("enc_reopen");
+    let keys = Keys::generate();
+    let pk = keys.public_key().to_hex();
+    let key = [42u8; 32];
+
+    let mgr = MlsManager::new_with_key(&path, &pk, key).expect("first open succeeds");
+    assert!(mgr.is_encrypted(), "manager must report encrypted=true");
+    drop(mgr);
+
+    // Reopen with the same key — should succeed.
+    let mgr2 = MlsManager::new_with_key(&path, &pk, key).expect("reopen with same key succeeds");
+    assert!(mgr2.is_encrypted());
+}
+
+#[test]
+fn issue_178_1_encrypted_db_rejects_wrong_key() {
+    let path = unique_db_path("enc_wrongkey");
+    let keys = Keys::generate();
+    let pk = keys.public_key().to_hex();
+    let key_a = [1u8; 32];
+    let key_b = [2u8; 32];
+
+    let mgr = MlsManager::new_with_key(&path, &pk, key_a).expect("first open");
+    drop(mgr);
+
+    let res = MlsManager::new_with_key(&path, &pk, key_b);
+    assert!(
+        res.is_err(),
+        "opening an encrypted DB with the wrong key must fail"
+    );
+}
+
+#[test]
+fn issue_178_1_derive_mls_db_key_is_deterministic() {
+    let secret = [7u8; 32];
+    let salt = b"io.nurunuru.mdk.v1.test";
+
+    let k1 = derive_mls_db_key(&secret, salt);
+    let k2 = derive_mls_db_key(&secret, salt);
+    assert_eq!(k1, k2, "HKDF derivation must be deterministic");
+
+    let k3 = derive_mls_db_key(&secret, b"different.salt");
+    assert_ne!(k1, k3, "different salt must yield different key");
+
+    let k4 = derive_mls_db_key(&[8u8; 32], salt);
+    assert_ne!(k1, k4, "different secret must yield different key");
+}
+
+// ── #4 Split process_welcome / accept_welcome / decline_welcome ──────────────
+
+#[tokio::test]
+async fn issue_178_4_preview_then_decline_does_not_create_active_group() {
+    // Alice creates a group with Bob; we preview the Welcome on Bob's engine
+    // and decline it. Bob's groups list must remain empty.
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+
+    let alice = engine_for(&alice_keys, "preview_decline_alice").await;
+    let bob = engine_for(&bob_keys, "preview_decline_bob").await;
+
+    // Bob publishes a KeyPackage (via the engine's create + we sign it manually).
+    let bob_pkg = bob.mls_create_key_package().await.unwrap();
+    let bob_kp_event = {
+        let mut tags: Vec<Tag> = Vec::new();
+        for raw in &bob_pkg.tags {
+            if let Ok(tag) = Tag::parse(raw.iter().map(|s| s.as_str())) {
+                tags.push(tag);
+            }
+        }
+        let signer = bob.client_signer_for_tests().await.unwrap();
+        EventBuilder::new(Kind::from(bob_pkg.kind as u16), bob_pkg.content.clone())
+            .tags(tags)
+            .sign(&signer)
+            .await
+            .unwrap()
+    };
+
+    let group_info = alice
+        .mls_create_group(
+            "Preview/Decline Group".to_string(),
+            vec![alice_keys.public_key().to_hex()],
+            vec!["wss://relay.example".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let add_result = alice
+        .mls_add_member(&group_info.group_id_hex, &bob_kp_event.as_json())
+        .await
+        .unwrap();
+    alice
+        .mls_merge_pending_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+
+    let gift_wrap = add_result.welcome_event_data.gift_wrapped_event_json;
+    assert!(!gift_wrap.is_empty(), "must produce gift-wrap");
+
+    // Bob *previews* — no group should be created yet.
+    let pending = bob.mls_preview_welcome(&gift_wrap).await.unwrap();
+    assert_eq!(pending.group_id_hex, group_info.group_id_hex);
+    let bob_groups_pre = bob.mls_list_groups().await.unwrap();
+    assert!(
+        bob_groups_pre.iter().all(|g| g.member_pubkeys.is_empty()),
+        "preview must not create an active group with members"
+    );
+
+    // Pending list should surface this welcome.
+    let pending_list = bob.mls_get_pending_welcomes().await.unwrap();
+    assert!(
+        pending_list
+            .iter()
+            .any(|p| p.welcome_event_id_hex == pending.welcome_event_id_hex),
+        "previewed welcome should appear in get_pending_welcomes"
+    );
+
+    // Bob declines — group must not have an active state.
+    bob.mls_decline_welcome(&pending.welcome_event_id_hex)
+        .await
+        .unwrap();
+
+    let pending_list_after = bob.mls_get_pending_welcomes().await.unwrap();
+    assert!(
+        pending_list_after
+            .iter()
+            .all(|p| p.welcome_event_id_hex != pending.welcome_event_id_hex),
+        "declined welcome must no longer be pending"
+    );
+}
+
+#[tokio::test]
+async fn issue_178_4_preview_then_accept_joins_group() {
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+    let alice = engine_for(&alice_keys, "preview_accept_alice").await;
+    let bob = engine_for(&bob_keys, "preview_accept_bob").await;
+
+    let bob_pkg = bob.mls_create_key_package().await.unwrap();
+    let bob_kp_event = {
+        let mut tags: Vec<Tag> = Vec::new();
+        for raw in &bob_pkg.tags {
+            if let Ok(tag) = Tag::parse(raw.iter().map(|s| s.as_str())) {
+                tags.push(tag);
+            }
+        }
+        let signer = bob.client_signer_for_tests().await.unwrap();
+        EventBuilder::new(Kind::from(bob_pkg.kind as u16), bob_pkg.content.clone())
+            .tags(tags)
+            .sign(&signer)
+            .await
+            .unwrap()
+    };
+
+    let group_info = alice
+        .mls_create_group(
+            "Accept Group".to_string(),
+            vec![alice_keys.public_key().to_hex()],
+            vec!["wss://relay.example".to_string()],
+        )
+        .await
+        .unwrap();
+    let add_result = alice
+        .mls_add_member(&group_info.group_id_hex, &bob_kp_event.as_json())
+        .await
+        .unwrap();
+    alice
+        .mls_merge_pending_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+
+    let pending = bob
+        .mls_preview_welcome(&add_result.welcome_event_data.gift_wrapped_event_json)
+        .await
+        .unwrap();
+    let accepted = bob
+        .mls_accept_welcome(&pending.welcome_event_id_hex)
+        .await
+        .unwrap();
+    assert_eq!(accepted.group_id_hex, group_info.group_id_hex);
+
+    let groups = bob.mls_list_groups().await.unwrap();
+    assert!(
+        groups
+            .iter()
+            .any(|g| g.group_id_hex == group_info.group_id_hex && g.member_pubkeys.len() >= 2),
+        "after accept Bob must be a group member"
+    );
+}
+
+// ── #5 Structured Commit delta ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn issue_178_5_commit_carries_added_member_pubkeys() {
+    // Alice and Bob join a group. Alice then adds Carol and publishes the
+    // commit. When Bob processes that commit, the wrapper must surface Carol's
+    // pubkey in `added_pubkeys` so Bob's UI does not need to re-query
+    // get_group_info.
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+    let carol_keys = Keys::generate();
+    let alice = engine_for(&alice_keys, "commit_delta_alice").await;
+    let bob = engine_for(&bob_keys, "commit_delta_bob").await;
+    let carol = engine_for(&carol_keys, "commit_delta_carol").await;
+
+    let bob_pkg = bob.mls_create_key_package().await.unwrap();
+    let bob_kp_event = {
+        let mut tags: Vec<Tag> = Vec::new();
+        for raw in &bob_pkg.tags {
+            if let Ok(tag) = Tag::parse(raw.iter().map(|s| s.as_str())) {
+                tags.push(tag);
+            }
+        }
+        let signer = bob.client_signer_for_tests().await.unwrap();
+        EventBuilder::new(Kind::from(bob_pkg.kind as u16), bob_pkg.content.clone())
+            .tags(tags)
+            .sign(&signer)
+            .await
+            .unwrap()
+    };
+    let carol_pkg = carol.mls_create_key_package().await.unwrap();
+    let carol_kp_event = {
+        let mut tags: Vec<Tag> = Vec::new();
+        for raw in &carol_pkg.tags {
+            if let Ok(tag) = Tag::parse(raw.iter().map(|s| s.as_str())) {
+                tags.push(tag);
+            }
+        }
+        let signer = carol.client_signer_for_tests().await.unwrap();
+        EventBuilder::new(Kind::from(carol_pkg.kind as u16), carol_pkg.content.clone())
+            .tags(tags)
+            .sign(&signer)
+            .await
+            .unwrap()
+    };
+
+    let group_info = alice
+        .mls_create_group(
+            "Delta Group".to_string(),
+            vec![alice_keys.public_key().to_hex()],
+            vec!["wss://relay.example".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // Alice adds Bob first; Bob joins.
+    let bob_add = alice
+        .mls_add_member(&group_info.group_id_hex, &bob_kp_event.as_json())
+        .await
+        .unwrap();
+    alice
+        .mls_merge_pending_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+    bob.mls_process_welcome(&bob_add.welcome_event_data.gift_wrapped_event_json)
+        .await
+        .unwrap();
+
+    // Bob runs his MIP-02 post-join self-update so his epoch matches Alice.
+    let bob_self_update = bob
+        .mls_create_recovery_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+    bob.mls_merge_pending_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+    let _ = alice
+        .mls_process_message_result(&group_info.group_id_hex, &bob_self_update.content)
+        .await
+        .unwrap();
+
+    // Alice adds Carol — this is the commit Bob will observe.
+    let carol_add = alice
+        .mls_add_member(&group_info.group_id_hex, &carol_kp_event.as_json())
+        .await
+        .unwrap();
+    alice
+        .mls_merge_pending_commit(&group_info.group_id_hex)
+        .await
+        .unwrap();
+
+    let bob_observation = bob
+        .mls_process_message_result(
+            &group_info.group_id_hex,
+            &carol_add.commit_event_data.content,
+        )
+        .await
+        .unwrap();
+
+    match bob_observation {
+        MlsProcessResult::Commit {
+            delta,
+            group_id_hex,
+            ..
+        } => {
+            assert_eq!(group_id_hex, group_info.group_id_hex);
+            assert!(
+                delta
+                    .added_pubkeys
+                    .iter()
+                    .any(|pk| pk.eq_ignore_ascii_case(&carol_keys.public_key().to_hex())),
+                "Bob's view of Alice's add-Carol commit must include Carol's pubkey in added_pubkeys, got {delta:?}"
+            );
+            assert!(
+                delta.removed_pubkeys.is_empty(),
+                "no member was removed, got {:?}",
+                delta.removed_pubkeys
+            );
+            assert!(
+                delta.epoch_after >= 2,
+                "epoch should have advanced past join"
+            );
+        }
+        other => panic!("expected structured Commit with added/removed delta, got {other:?}"),
+    }
+}
+
+// ── #9 / #10 Subscription helpers ───────────────────────────────────────────
+
+#[tokio::test]
+async fn issue_178_9_mls_subscribe_welcomes_returns_subscription_id() {
+    let keys = Keys::generate();
+    let engine = engine_for(&keys, "subscribe_welcomes").await;
+    let sub_id = engine.mls_subscribe_welcomes(None).await.unwrap();
+    assert!(
+        !sub_id.is_empty(),
+        "subscribe_welcomes must return a sub id"
+    );
+    engine.unsubscribe_stream(&sub_id).await.unwrap();
+}
+
+#[tokio::test]
+async fn issue_178_10_mls_subscribe_keypackage_rotations_returns_subscription_id() {
+    let alice = Keys::generate();
+    let bob = Keys::generate();
+    let engine = engine_for(&alice, "subscribe_keypackage").await;
+    let sub_id = engine
+        .mls_subscribe_keypackage_rotations(vec![bob.public_key()])
+        .await
+        .unwrap();
+    assert!(
+        !sub_id.is_empty(),
+        "subscribe_keypackage_rotations must return a sub id"
+    );
+    engine.unsubscribe_stream(&sub_id).await.unwrap();
+}

--- a/rust-engine/nurunuru-core/tests/mls_marmot_flow.rs
+++ b/rust-engine/nurunuru-core/tests/mls_marmot_flow.rs
@@ -234,9 +234,19 @@ async fn marmot_welcome_giftwrap_and_message_flow_works() {
         .await
         .unwrap();
     match self_update_result {
+        // Issue #178 #5: a self-update commit is now reported as a structured
+        // Commit (with an empty membership delta — the self-update doesn't
+        // add/remove members) rather than the opaque StateUpdate { kind: "commit" }.
+        nurunuru_core::types::MlsProcessResult::Commit { delta, .. } => {
+            assert!(
+                delta.added_pubkeys.is_empty() && delta.removed_pubkeys.is_empty(),
+                "self-update commit must not add/remove members, got {:?}",
+                delta
+            );
+        }
         nurunuru_core::types::MlsProcessResult::StateUpdate { .. } => {}
         other => panic!(
-            "expected state update for self-update commit, got {:?}",
+            "expected commit/state-update for self-update commit, got {:?}",
             other
         ),
     }

--- a/rust-engine/nurunuru-core/tests/mls_out_of_order.rs
+++ b/rust-engine/nurunuru-core/tests/mls_out_of_order.rs
@@ -95,6 +95,12 @@ fn assert_duplicate_idempotent(result: Result<MlsProcessResult, NuruNuruError>, 
                 "duplicate {label} returned an application message but content was empty"
             );
         }
+        Ok(MlsProcessResult::Commit { .. }) => {
+            // A duplicate that MDK treats as a fresh commit (idempotent path).
+        }
+        Ok(MlsProcessResult::NeedsSelfUpdate { .. }) => {
+            // A pending proposal is idempotent state — no error here.
+        }
         Ok(MlsProcessResult::StateUpdate { kind }) => {
             assert!(
                 kind == "commit"
@@ -206,11 +212,17 @@ async fn marmot_out_of_order_kind445_message_retries_after_missing_commit_and_du
         .await
         .unwrap();
     match commit_result {
+        // Issue #178 #5: self-update commit now arrives as a structured Commit
+        // (empty member delta because self-update doesn't add/remove members).
+        MlsProcessResult::Commit { delta, .. } => assert!(
+            delta.added_pubkeys.is_empty() && delta.removed_pubkeys.is_empty(),
+            "self-update commit must have empty member delta, got {delta:?}"
+        ),
         MlsProcessResult::StateUpdate { kind } => assert_eq!(
             kind, "commit",
             "self-update commit should be a clear state-update result"
         ),
-        other => panic!("expected self-update commit StateUpdate, got {other:?}"),
+        other => panic!("expected self-update commit, got {other:?}"),
     }
 
     // After the missing commit has been processed, retrying the exact same message succeeds.

--- a/rust-engine/nurunuru-core/tests/mls_pending_commit.rs
+++ b/rust-engine/nurunuru-core/tests/mls_pending_commit.rs
@@ -248,10 +248,18 @@ async fn merge_pending_commit_allows_followup_state_update() {
         .await
         .unwrap();
     match processed {
+        // Issue #178 #5: self-update commit is now structured Commit with
+        // empty member delta (no add/remove on self-update).
+        nurunuru_core::types::MlsProcessResult::Commit { delta, .. } => {
+            assert!(
+                delta.added_pubkeys.is_empty() && delta.removed_pubkeys.is_empty(),
+                "Bob self-update must have empty member delta, got {delta:?}"
+            );
+        }
         nurunuru_core::types::MlsProcessResult::StateUpdate { kind } => {
             assert_eq!(kind, "commit", "Bob self-update must process as a commit");
         }
-        other => panic!("expected Bob self-update to be a state update, got {other:?}"),
+        other => panic!("expected Bob self-update commit, got {other:?}"),
     }
 
     let expected = "message after pending add-member commit was merged";

--- a/rust-engine/nurunuru-core/tests/mls_self_update_flow.rs
+++ b/rust-engine/nurunuru-core/tests/mls_self_update_flow.rs
@@ -182,10 +182,17 @@ async fn post_join_self_update_full_roundtrip_allows_bidirectional_messages() {
         .await
         .unwrap();
     match self_update_result {
+        // Issue #178 #5: structured Commit with empty member delta.
+        nurunuru_core::types::MlsProcessResult::Commit { delta, .. } => {
+            assert!(
+                delta.added_pubkeys.is_empty() && delta.removed_pubkeys.is_empty(),
+                "self-update must have empty member delta, got {delta:?}"
+            );
+        }
         nurunuru_core::types::MlsProcessResult::StateUpdate { kind } => {
             assert_eq!(kind, "commit", "self-update must process as a commit");
         }
-        other => panic!("expected self-update state update, got {other:?}"),
+        other => panic!("expected self-update commit, got {other:?}"),
     }
 
     // Regression lock: after Bob's post-join self-update, both directions must

--- a/rust-engine/nurunuru-ffi/bindgen/kotlin-out/uniffi/nurunuru/nurunuru.kt
+++ b/rust-engine/nurunuru-ffi/bindgen/kotlin-out/uniffi/nurunuru/nurunuru.kt
@@ -850,6 +850,24 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -865,7 +883,9 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 // when the library is loaded.
 internal interface IntegrityCheckingUniffiLib : Library {
     // Integrity check functions only
-    fun uniffi_uniffi_nurunuru_checksum_func_init_engine(
+    fun uniffi_uniffi_nurunuru_checksum_func_derive_mls_db_key_from_secret(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_func_init_engine(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_add_relay(
 ): Short
@@ -917,6 +937,8 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_login(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mark_not_interested(
 ): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_accept_welcome(
+): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_add_member(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_clear_pending_commit(
@@ -929,6 +951,8 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_create_message(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_create_recovery_commit(
 ): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_decline_welcome(
+): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_delete_consumed_key_package_by_hash_ref(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_delete_consumed_key_package_from_event_json(
@@ -936,6 +960,8 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_delete_consumed_ke
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_get_group_info(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_get_message_history(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_get_pending_welcomes(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_groups_needing_self_update(
 ): Short
@@ -945,6 +971,8 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_list_groups(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_merge_pending_commit(
 ): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_preview_welcome(
+): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_message(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_message_result(
@@ -952,6 +980,12 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_message_re
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_welcome(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_remove_member(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_reset(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_subscribe_keypackage_rotations(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_subscribe_welcomes(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_validate_key_package_event(
 ): Short
@@ -988,6 +1022,8 @@ fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_repost(
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_search(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_send_dm(
+): Short
+fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_set_mls_db_key(
 ): Short
 fun uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_start_live_subscription(
 ): Short
@@ -1108,6 +1144,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_login(`ptr`: Pointer,`pubkey
 ): Unit
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mark_not_interested(`ptr`: Pointer,`eventId`: RustBuffer.ByValue,`authorPubkey`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_accept_welcome(`ptr`: Pointer,`welcomeEventIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_add_member(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,`keyPackageEventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_clear_pending_commit(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1120,6 +1158,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_create_message(`ptr`: Po
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_create_recovery_commit(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_decline_welcome(`ptr`: Pointer,`welcomeEventIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_delete_consumed_key_package_by_hash_ref(`ptr`: Pointer,`hashRef`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_delete_consumed_key_package_from_event_json(`ptr`: Pointer,`keyPackageEventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1127,6 +1167,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_delete_consumed_key_pack
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_get_group_info(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_get_message_history(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,`limit`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_get_pending_welcomes(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_groups_needing_self_update(`ptr`: Pointer,`thresholdSecs`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1136,6 +1178,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_list_groups(`ptr`: Point
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_merge_pending_commit(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_preview_welcome(`ptr`: Pointer,`welcomeEventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_process_message(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,`eventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_process_message_result(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,`eventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1143,6 +1187,12 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_process_message_result(`
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_process_welcome(`ptr`: Pointer,`welcomeEventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_remove_member(`ptr`: Pointer,`groupIdHex`: RustBuffer.ByValue,`memberPubkey`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_reset(`ptr`: Pointer,`newPubkeyHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_subscribe_keypackage_rotations(`ptr`: Pointer,`contactPubkeys`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_subscribe_welcomes(`ptr`: Pointer,`sinceSecs`: Long,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_validate_key_package_event(`ptr`: Pointer,`keyPackageEventJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1180,6 +1230,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_search(`ptr`: Pointer,`query
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_send_dm(`ptr`: Pointer,`recipientHex`: RustBuffer.ByValue,`content`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
+fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_set_mls_db_key(`ptr`: Pointer,`key`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_start_live_subscription(`ptr`: Pointer,`authors`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_stop_live_subscription(`ptr`: Pointer,`subId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1187,6 +1239,8 @@ fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_stop_live_subscription(`ptr`
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_unfollow_user(`ptr`: Pointer,`targetPubkeyHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_uniffi_nurunuru_fn_method_nurunuruclient_update_profile(`ptr`: Pointer,`metadataJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_uniffi_nurunuru_fn_func_derive_mls_db_key_from_secret(`secretKeyHex`: RustBuffer.ByValue,`appSalt`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_uniffi_nurunuru_fn_func_init_engine(`dbPath`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1316,6 +1370,9 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
 }
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
+    if (lib.uniffi_uniffi_nurunuru_checksum_func_derive_mls_db_key_from_secret() != 19985.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_uniffi_nurunuru_checksum_func_init_engine() != 52824.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1394,6 +1451,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mark_not_interested() != 2204.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_accept_welcome() != 19211.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_add_member() != 24579.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1412,6 +1472,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_create_recovery_commit() != 3656.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_decline_welcome() != 4269.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_delete_consumed_key_package_by_hash_ref() != 13887.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1422,6 +1485,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_get_message_history() != 36205.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_get_pending_welcomes() != 20871.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_groups_needing_self_update() != 10252.toShort()) {
@@ -1436,16 +1502,28 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_merge_pending_commit() != 48880.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_preview_welcome() != 765.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_message() != 20654.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_message_result() != 18367.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_welcome() != 43793.toShort()) {
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_process_welcome() != 55489.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_remove_member() != 42604.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_reset() != 24506.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_subscribe_keypackage_rotations() != 29071.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_subscribe_welcomes() != 25684.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_mls_validate_key_package_event() != 20255.toShort()) {
@@ -1500,6 +1578,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_send_dm() != 32235.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_set_mls_db_key() != 57395.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_uniffi_nurunuru_checksum_method_nurunuruclient_start_live_subscription() != 15505.toShort()) {
@@ -2109,6 +2190,12 @@ public interface NuruNuruClientInterface {
     fun `markNotInterested`(`eventId`: kotlin.String, `authorPubkey`: kotlin.String)
     
     /**
+     * Accept a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+     * The id is the `welcome_event_id_hex` field returned by `mls_preview_welcome`.
+     */
+    fun `mlsAcceptWelcome`(`welcomeEventIdHex`: kotlin.String): FfiPendingWelcome
+    
+    /**
      * Add a member to a group using their Kind-30443 KeyPackage event JSON.
      *
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
@@ -2153,6 +2240,11 @@ public interface NuruNuruClientInterface {
     fun `mlsCreateRecoveryCommit`(`groupIdHex`: kotlin.String): FfiEncryptedMessageData
     
     /**
+     * Decline a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+     */
+    fun `mlsDeclineWelcome`(`welcomeEventIdHex`: kotlin.String)
+    
+    /**
      * Delete consumed KeyPackage private/init-key material using the exact hash_ref returned at creation.
      */
     fun `mlsDeleteConsumedKeyPackageByHashRef`(`hashRef`: kotlin.ByteArray)
@@ -2176,6 +2268,11 @@ public interface NuruNuruClientInterface {
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
      */
     fun `mlsGetMessageHistory`(`groupIdHex`: kotlin.String, `limit`: kotlin.ULong): List<FfiDecryptedMessage>
+    
+    /**
+     * List Welcomes that have been previewed but not yet accepted/declined.
+     */
+    fun `mlsGetPendingWelcomes`(): List<FfiPendingWelcome>
     
     /**
      * Return Nostr group IDs (64-char hex Kind-445 `h` tag values) that need self-update.
@@ -2210,6 +2307,13 @@ public interface NuruNuruClientInterface {
     fun `mlsMergePendingCommit`(`groupIdHex`: kotlin.String)
     
     /**
+     * Stage an incoming Welcome without joining. Returns the pending welcome
+     * so the UI can show "Bob invited you to Foo" before any cryptographic
+     * state is created. Follow with `mls_accept_welcome` or `mls_decline_welcome`.
+     */
+    fun `mlsPreviewWelcome`(`welcomeEventJson`: kotlin.String): FfiPendingWelcome
+    
+    /**
      * Backward-compatible wrapper used by older clients.
      *
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
@@ -2224,9 +2328,8 @@ public interface NuruNuruClientInterface {
     fun `mlsProcessMessageResult`(`groupIdHex`: kotlin.String, `eventJson`: kotlin.String): FfiMlsProcessResult
     
     /**
-     * Process an incoming Welcome event and join the group.
-     *
-     * Accepts both Kind 1059 (NIP-59 gift-wrapped, Marmot) and Kind 444 (legacy).
+     * Fused process+accept (back-compat). Issue #178 #4: prefer the split
+     * flow `mls_preview_welcome` → `mls_accept_welcome`/`mls_decline_welcome`.
      */
     fun `mlsProcessWelcome`(`welcomeEventJson`: kotlin.String): FfiMlsGroupInfo
     
@@ -2236,6 +2339,23 @@ public interface NuruNuruClientInterface {
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
      */
     fun `mlsRemoveMember`(`groupIdHex`: kotlin.String, `memberPubkey`: kotlin.String): FfiEncryptedMessageData
+    
+    /**
+     * Issue #178 #11: wipe + reopen the MLS DB for a new identity.
+     */
+    fun `mlsReset`(`newPubkeyHex`: kotlin.String)
+    
+    /**
+     * Issue #178 #10: subscribe to kind:30443 rotations from the given
+     * contacts (empty list = all kind:30443).
+     */
+    fun `mlsSubscribeKeypackageRotations`(`contactPubkeys`: List<kotlin.String>): kotlin.String
+    
+    /**
+     * Issue #178 #9: subscribe to my Welcomes (kind:1059 #p=self). Returns
+     * a sub_id for `poll_live_events`/`stop_live_subscription`. `since_secs=0` means now.
+     */
+    fun `mlsSubscribeWelcomes`(`sinceSecs`: kotlin.ULong): kotlin.String
     
     /**
      * Strictly validate a KeyPackage event JSON (MIP-00).
@@ -2374,6 +2494,11 @@ public interface NuruNuruClientInterface {
      * the NIP-17 → NIP-EE migration period.
      */
     fun `sendDm`(`recipientHex`: kotlin.String, `content`: kotlin.String)
+    
+    /**
+     * Issue #178 #1: set the 32-byte SQLCipher key. Call before `login()`.
+     */
+    fun `setMlsDbKey`(`key`: kotlin.ByteArray)
     
     /**
      * Start a persistent relay subscription for live events.
@@ -2947,6 +3072,23 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
 
     
     /**
+     * Accept a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+     * The id is the `welcome_event_id_hex` field returned by `mls_preview_welcome`.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsAcceptWelcome`(`welcomeEventIdHex`: kotlin.String): FfiPendingWelcome {
+            return FfiConverterTypeFfiPendingWelcome.lift(
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_accept_welcome(
+        it, FfiConverterString.lower(`welcomeEventIdHex`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
      * Add a member to a group using their Kind-30443 KeyPackage event JSON.
      *
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
@@ -3056,6 +3198,21 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
 
     
     /**
+     * Decline a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsDeclineWelcome`(`welcomeEventIdHex`: kotlin.String)
+        = 
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_decline_welcome(
+        it, FfiConverterString.lower(`welcomeEventIdHex`),_status)
+}
+    }
+    
+    
+
+    
+    /**
      * Delete consumed KeyPackage private/init-key material using the exact hash_ref returned at creation.
      */
     @Throws(NuruNuruFfiException::class)override fun `mlsDeleteConsumedKeyPackageByHashRef`(`hashRef`: kotlin.ByteArray)
@@ -3115,6 +3272,22 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
     uniffiRustCallWithError(NuruNuruFfiException) { _status ->
     UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_get_message_history(
         it, FfiConverterString.lower(`groupIdHex`),FfiConverterULong.lower(`limit`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * List Welcomes that have been previewed but not yet accepted/declined.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsGetPendingWelcomes`(): List<FfiPendingWelcome> {
+            return FfiConverterSequenceTypeFfiPendingWelcome.lift(
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_get_pending_welcomes(
+        it, _status)
 }
     }
     )
@@ -3198,6 +3371,24 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
 
     
     /**
+     * Stage an incoming Welcome without joining. Returns the pending welcome
+     * so the UI can show "Bob invited you to Foo" before any cryptographic
+     * state is created. Follow with `mls_accept_welcome` or `mls_decline_welcome`.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsPreviewWelcome`(`welcomeEventJson`: kotlin.String): FfiPendingWelcome {
+            return FfiConverterTypeFfiPendingWelcome.lift(
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_preview_welcome(
+        it, FfiConverterString.lower(`welcomeEventJson`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
      * Backward-compatible wrapper used by older clients.
      *
      * group_id_hex argument: external group id is Nostr group id, wrapper resolves to internal MLS group id.
@@ -3234,9 +3425,8 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
 
     
     /**
-     * Process an incoming Welcome event and join the group.
-     *
-     * Accepts both Kind 1059 (NIP-59 gift-wrapped, Marmot) and Kind 444 (legacy).
+     * Fused process+accept (back-compat). Issue #178 #4: prefer the split
+     * flow `mls_preview_welcome` → `mls_accept_welcome`/`mls_decline_welcome`.
      */
     @Throws(NuruNuruFfiException::class)override fun `mlsProcessWelcome`(`welcomeEventJson`: kotlin.String): FfiMlsGroupInfo {
             return FfiConverterTypeFfiMlsGroupInfo.lift(
@@ -3262,6 +3452,55 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
     uniffiRustCallWithError(NuruNuruFfiException) { _status ->
     UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_remove_member(
         it, FfiConverterString.lower(`groupIdHex`),FfiConverterString.lower(`memberPubkey`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Issue #178 #11: wipe + reopen the MLS DB for a new identity.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsReset`(`newPubkeyHex`: kotlin.String)
+        = 
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_reset(
+        it, FfiConverterString.lower(`newPubkeyHex`),_status)
+}
+    }
+    
+    
+
+    
+    /**
+     * Issue #178 #10: subscribe to kind:30443 rotations from the given
+     * contacts (empty list = all kind:30443).
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsSubscribeKeypackageRotations`(`contactPubkeys`: List<kotlin.String>): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_subscribe_keypackage_rotations(
+        it, FfiConverterSequenceString.lower(`contactPubkeys`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * Issue #178 #9: subscribe to my Welcomes (kind:1059 #p=self). Returns
+     * a sub_id for `poll_live_events`/`stop_live_subscription`. `since_secs=0` means now.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `mlsSubscribeWelcomes`(`sinceSecs`: kotlin.ULong): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_mls_subscribe_welcomes(
+        it, FfiConverterULong.lower(`sinceSecs`),_status)
 }
     }
     )
@@ -3594,6 +3833,21 @@ open class NuruNuruClient: Disposable, AutoCloseable, NuruNuruClientInterface
     uniffiRustCallWithError(NuruNuruFfiException) { _status ->
     UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_send_dm(
         it, FfiConverterString.lower(`recipientHex`),FfiConverterString.lower(`content`),_status)
+}
+    }
+    
+    
+
+    
+    /**
+     * Issue #178 #1: set the 32-byte SQLCipher key. Call before `login()`.
+     */
+    @Throws(NuruNuruFfiException::class)override fun `setMlsDbKey`(`key`: kotlin.ByteArray)
+        = 
+    callWithPointer {
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_method_nurunuruclient_set_mls_db_key(
+        it, FfiConverterByteArray.lower(`key`),_status)
 }
     }
     
@@ -4011,6 +4265,78 @@ public object FfiConverterTypeFfiMlsGroupInfo: FfiConverterRustBuffer<FfiMlsGrou
 
 
 
+data class FfiPendingWelcome (
+    /**
+     * Inner Welcome rumor (kind:444) event id — the lookup key for
+     * `mls_accept_welcome` / `mls_decline_welcome`.
+     */
+    var `welcomeEventIdHex`: kotlin.String, 
+    /**
+     * Outer NIP-59 gift-wrap (kind:1059) event id — for app-side dedup
+     * against relay-level caches.
+     */
+    var `wrapperEventIdHex`: kotlin.String, 
+    var `groupIdHex`: kotlin.String, 
+    var `groupName`: kotlin.String, 
+    var `groupDescription`: kotlin.String, 
+    var `groupAdminPubkeys`: List<kotlin.String>, 
+    var `groupRelays`: List<kotlin.String>, 
+    var `welcomerPubkey`: kotlin.String, 
+    var `memberCount`: kotlin.UInt, 
+    var `isDm`: kotlin.Boolean
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeFfiPendingWelcome: FfiConverterRustBuffer<FfiPendingWelcome> {
+    override fun read(buf: ByteBuffer): FfiPendingWelcome {
+        return FfiPendingWelcome(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterSequenceString.read(buf),
+            FfiConverterSequenceString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterUInt.read(buf),
+            FfiConverterBoolean.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: FfiPendingWelcome) = (
+            FfiConverterString.allocationSize(value.`welcomeEventIdHex`) +
+            FfiConverterString.allocationSize(value.`wrapperEventIdHex`) +
+            FfiConverterString.allocationSize(value.`groupIdHex`) +
+            FfiConverterString.allocationSize(value.`groupName`) +
+            FfiConverterString.allocationSize(value.`groupDescription`) +
+            FfiConverterSequenceString.allocationSize(value.`groupAdminPubkeys`) +
+            FfiConverterSequenceString.allocationSize(value.`groupRelays`) +
+            FfiConverterString.allocationSize(value.`welcomerPubkey`) +
+            FfiConverterUInt.allocationSize(value.`memberCount`) +
+            FfiConverterBoolean.allocationSize(value.`isDm`)
+    )
+
+    override fun write(value: FfiPendingWelcome, buf: ByteBuffer) {
+            FfiConverterString.write(value.`welcomeEventIdHex`, buf)
+            FfiConverterString.write(value.`wrapperEventIdHex`, buf)
+            FfiConverterString.write(value.`groupIdHex`, buf)
+            FfiConverterString.write(value.`groupName`, buf)
+            FfiConverterString.write(value.`groupDescription`, buf)
+            FfiConverterSequenceString.write(value.`groupAdminPubkeys`, buf)
+            FfiConverterSequenceString.write(value.`groupRelays`, buf)
+            FfiConverterString.write(value.`welcomerPubkey`, buf)
+            FfiConverterUInt.write(value.`memberCount`, buf)
+            FfiConverterBoolean.write(value.`isDm`, buf)
+    }
+}
+
+
+
 data class FfiScoredPost (
     var `eventId`: kotlin.String, 
     var `pubkey`: kotlin.String, 
@@ -4156,6 +4482,31 @@ sealed class FfiMlsProcessResult {
         companion object
     }
     
+    /**
+     * A Commit was applied. Carries the membership delta so the UI doesn't
+     * need to re-query group info (issue #178 #5).
+     */
+    data class Commit(
+        val `groupIdHex`: kotlin.String, 
+        val `addedPubkeys`: List<kotlin.String>, 
+        val `removedPubkeys`: List<kotlin.String>, 
+        val `epochAfter`: kotlin.ULong) : FfiMlsProcessResult() {
+        companion object
+    }
+    
+    /**
+     * A pending proposal was stored — call `mls_create_recovery_commit` to
+     * resolve it before the group stalls (issue #178 #6).
+     */
+    data class NeedsSelfUpdate(
+        val `groupIdHex`: kotlin.String, 
+        val `reason`: kotlin.String) : FfiMlsProcessResult() {
+        companion object
+    }
+    
+    /**
+     * Catch-all for unprocessable / unhandled results.
+     */
     data class StateUpdate(
         val `kind`: kotlin.String) : FfiMlsProcessResult() {
         companion object
@@ -4175,7 +4526,17 @@ public object FfiConverterTypeFfiMlsProcessResult : FfiConverterRustBuffer<FfiMl
             1 -> FfiMlsProcessResult.Application(
                 FfiConverterTypeFfiDecryptedMessage.read(buf),
                 )
-            2 -> FfiMlsProcessResult.StateUpdate(
+            2 -> FfiMlsProcessResult.Commit(
+                FfiConverterString.read(buf),
+                FfiConverterSequenceString.read(buf),
+                FfiConverterSequenceString.read(buf),
+                FfiConverterULong.read(buf),
+                )
+            3 -> FfiMlsProcessResult.NeedsSelfUpdate(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            4 -> FfiMlsProcessResult.StateUpdate(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid enum value, something is very wrong!!")
@@ -4188,6 +4549,24 @@ public object FfiConverterTypeFfiMlsProcessResult : FfiConverterRustBuffer<FfiMl
             (
                 4UL
                 + FfiConverterTypeFfiDecryptedMessage.allocationSize(value.`message`)
+            )
+        }
+        is FfiMlsProcessResult.Commit -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`groupIdHex`)
+                + FfiConverterSequenceString.allocationSize(value.`addedPubkeys`)
+                + FfiConverterSequenceString.allocationSize(value.`removedPubkeys`)
+                + FfiConverterULong.allocationSize(value.`epochAfter`)
+            )
+        }
+        is FfiMlsProcessResult.NeedsSelfUpdate -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+                + FfiConverterString.allocationSize(value.`groupIdHex`)
+                + FfiConverterString.allocationSize(value.`reason`)
             )
         }
         is FfiMlsProcessResult.StateUpdate -> {
@@ -4206,8 +4585,22 @@ public object FfiConverterTypeFfiMlsProcessResult : FfiConverterRustBuffer<FfiMl
                 FfiConverterTypeFfiDecryptedMessage.write(value.`message`, buf)
                 Unit
             }
-            is FfiMlsProcessResult.StateUpdate -> {
+            is FfiMlsProcessResult.Commit -> {
                 buf.putInt(2)
+                FfiConverterString.write(value.`groupIdHex`, buf)
+                FfiConverterSequenceString.write(value.`addedPubkeys`, buf)
+                FfiConverterSequenceString.write(value.`removedPubkeys`, buf)
+                FfiConverterULong.write(value.`epochAfter`, buf)
+                Unit
+            }
+            is FfiMlsProcessResult.NeedsSelfUpdate -> {
+                buf.putInt(3)
+                FfiConverterString.write(value.`groupIdHex`, buf)
+                FfiConverterString.write(value.`reason`, buf)
+                Unit
+            }
+            is FfiMlsProcessResult.StateUpdate -> {
+                buf.putInt(4)
                 FfiConverterString.write(value.`kind`, buf)
                 Unit
             }
@@ -4523,6 +4916,34 @@ public object FfiConverterSequenceTypeFfiMlsGroupInfo: FfiConverterRustBuffer<Li
 /**
  * @suppress
  */
+public object FfiConverterSequenceTypeFfiPendingWelcome: FfiConverterRustBuffer<List<FfiPendingWelcome>> {
+    override fun read(buf: ByteBuffer): List<FfiPendingWelcome> {
+        val len = buf.getInt()
+        return List<FfiPendingWelcome>(len) {
+            FfiConverterTypeFfiPendingWelcome.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<FfiPendingWelcome>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeFfiPendingWelcome.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<FfiPendingWelcome>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeFfiPendingWelcome.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterSequenceTypeFfiScoredPost: FfiConverterRustBuffer<List<FfiScoredPost>> {
     override fun read(buf: ByteBuffer): List<FfiScoredPost> {
         val len = buf.getInt()
@@ -4600,6 +5021,20 @@ public object FfiConverterSequenceSequenceString: FfiConverterRustBuffer<List<Li
         }
     }
 }
+        /**
+         * HKDF-SHA256 over the secret key (hex or nsec) → 32-byte key for
+         * `set_mls_db_key`. `app_salt` scopes the key (e.g. `"io.nurunuru.mdk.v1"`).
+         */
+    @Throws(NuruNuruFfiException::class) fun `deriveMlsDbKeyFromSecret`(`secretKeyHex`: kotlin.String, `appSalt`: kotlin.String): kotlin.ByteArray {
+            return FfiConverterByteArray.lift(
+    uniffiRustCallWithError(NuruNuruFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_uniffi_nurunuru_fn_func_derive_mls_db_key_from_secret(
+        FfiConverterString.lower(`secretKeyHex`),FfiConverterString.lower(`appSalt`),_status)
+}
+    )
+    }
+    
+
         /**
          * One-time global initialisation. Call this once in `Application.onCreate()`
          * before creating any `NuruNuruClient`.

--- a/rust-engine/nurunuru-ffi/src/lib.rs
+++ b/rust-engine/nurunuru-ffi/src/lib.rs
@@ -791,6 +791,22 @@ impl NuruNuruClient {
                     },
                 }
             }
+            nurunuru_core::types::MlsProcessResult::Commit {
+                group_id_hex,
+                delta,
+            } => FfiMlsProcessResult::Commit {
+                group_id_hex,
+                added_pubkeys: delta.added_pubkeys,
+                removed_pubkeys: delta.removed_pubkeys,
+                epoch_after: delta.epoch_after,
+            },
+            nurunuru_core::types::MlsProcessResult::NeedsSelfUpdate {
+                group_id_hex,
+                reason,
+            } => FfiMlsProcessResult::NeedsSelfUpdate {
+                group_id_hex,
+                reason,
+            },
             nurunuru_core::types::MlsProcessResult::StateUpdate { kind } => {
                 FfiMlsProcessResult::StateUpdate { kind }
             }
@@ -807,13 +823,14 @@ impl NuruNuruClient {
     ) -> Result<FfiDecryptedMessage, NuruNuruFfiError> {
         match self.mls_process_message_result(group_id_hex, event_json)? {
             FfiMlsProcessResult::Application { message } => Ok(message),
-            FfiMlsProcessResult::StateUpdate { .. } => Err(NuruNuruFfiError::MlsStateUpdate),
+            FfiMlsProcessResult::Commit { .. }
+            | FfiMlsProcessResult::NeedsSelfUpdate { .. }
+            | FfiMlsProcessResult::StateUpdate { .. } => Err(NuruNuruFfiError::MlsStateUpdate),
         }
     }
 
-    /// Process an incoming Welcome event and join the group.
-    ///
-    /// Accepts both Kind 1059 (NIP-59 gift-wrapped, Marmot) and Kind 444 (legacy).
+    /// Fused process+accept (back-compat). Issue #178 #4: prefer the split
+    /// flow `mls_preview_welcome` → `mls_accept_welcome`/`mls_decline_welcome`.
     pub fn mls_process_welcome(
         &self,
         welcome_event_json: String,
@@ -823,6 +840,108 @@ impl NuruNuruClient {
             .block_on(self.engine.mls_process_welcome(&welcome_event_json))
             .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))?;
         Ok(core_group_info_to_ffi(info))
+    }
+
+    /// Stage an incoming Welcome without joining. Returns the pending welcome
+    /// so the UI can show "Bob invited you to Foo" before any cryptographic
+    /// state is created. Follow with `mls_accept_welcome` or `mls_decline_welcome`.
+    pub fn mls_preview_welcome(
+        &self,
+        welcome_event_json: String,
+    ) -> Result<FfiPendingWelcome, NuruNuruFfiError> {
+        let pending = self
+            .runtime
+            .block_on(self.engine.mls_preview_welcome(&welcome_event_json))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))?;
+        Ok(core_pending_welcome_to_ffi(pending))
+    }
+
+    /// Accept a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+    /// The id is the `welcome_event_id_hex` field returned by `mls_preview_welcome`.
+    pub fn mls_accept_welcome(
+        &self,
+        welcome_event_id_hex: String,
+    ) -> Result<FfiPendingWelcome, NuruNuruFfiError> {
+        let pending = self
+            .runtime
+            .block_on(self.engine.mls_accept_welcome(&welcome_event_id_hex))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))?;
+        Ok(core_pending_welcome_to_ffi(pending))
+    }
+
+    /// Decline a previously previewed Welcome by its **welcome event id** (kind:444 rumor id).
+    pub fn mls_decline_welcome(
+        &self,
+        welcome_event_id_hex: String,
+    ) -> Result<(), NuruNuruFfiError> {
+        self.runtime
+            .block_on(self.engine.mls_decline_welcome(&welcome_event_id_hex))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))
+    }
+
+    /// List Welcomes that have been previewed but not yet accepted/declined.
+    pub fn mls_get_pending_welcomes(&self) -> Result<Vec<FfiPendingWelcome>, NuruNuruFfiError> {
+        let pending = self
+            .runtime
+            .block_on(self.engine.mls_get_pending_welcomes())
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))?;
+        Ok(pending
+            .into_iter()
+            .map(core_pending_welcome_to_ffi)
+            .collect())
+    }
+
+    // ─── MLS subscriptions (issue #178 #9, #10) ───────────────────────────
+
+    /// Issue #178 #9: subscribe to my Welcomes (kind:1059 #p=self). Returns
+    /// a sub_id for `poll_live_events`/`stop_live_subscription`. `since_secs=0` means now.
+    pub fn mls_subscribe_welcomes(&self, since_secs: u64) -> Result<String, NuruNuruFfiError> {
+        let since = if since_secs == 0 {
+            None
+        } else {
+            Some(nostr::Timestamp::from(since_secs))
+        };
+        self.runtime
+            .block_on(self.engine.mls_subscribe_welcomes(since))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))
+    }
+
+    /// Issue #178 #10: subscribe to kind:30443 rotations from the given
+    /// contacts (empty list = all kind:30443).
+    pub fn mls_subscribe_keypackage_rotations(
+        &self,
+        contact_pubkeys: Vec<String>,
+    ) -> Result<String, NuruNuruFfiError> {
+        let pks: Vec<nostr::PublicKey> = contact_pubkeys
+            .iter()
+            .filter_map(|h| nostr::PublicKey::from_hex(h).ok())
+            .collect();
+        self.runtime
+            .block_on(self.engine.mls_subscribe_keypackage_rotations(pks))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))
+    }
+
+    // ─── MLS identity / encryption (issue #178 #1, #11) ───────────────────
+
+    /// Issue #178 #1: set the 32-byte SQLCipher key. Call before `login()`.
+    pub fn set_mls_db_key(&self, key: Vec<u8>) -> Result<(), NuruNuruFfiError> {
+        let bytes: [u8; 32] = key.try_into().map_err(|v: Vec<u8>| {
+            NuruNuruFfiError::EngineError(format!(
+                "set_mls_db_key: key must be 32 bytes, got {}",
+                v.len()
+            ))
+        })?;
+        self.runtime.block_on(self.engine.set_mls_db_key(bytes));
+        Ok(())
+    }
+
+    /// Issue #178 #11: wipe + reopen the MLS DB for a new identity.
+    pub fn mls_reset(&self, new_pubkey_hex: String) -> Result<(), NuruNuruFfiError> {
+        let pk = nostr::PublicKey::from_hex(&new_pubkey_hex)
+            .map_err(|e| NuruNuruFfiError::KeyError(e.to_string()))?;
+        self.runtime
+            .block_on(self.engine.mls_reset(pk))
+            .map_err(|e| NuruNuruFfiError::EngineError(e.to_string()))
     }
 
     /// Retrieve decrypted message history for a group from MDK's local SQLite.
@@ -1488,8 +1607,45 @@ pub struct FfiDecryptedMessage {
 
 #[derive(uniffi::Enum)]
 pub enum FfiMlsProcessResult {
-    Application { message: FfiDecryptedMessage },
-    StateUpdate { kind: String },
+    Application {
+        message: FfiDecryptedMessage,
+    },
+    /// A Commit was applied. Carries the membership delta so the UI doesn't
+    /// need to re-query group info (issue #178 #5).
+    Commit {
+        group_id_hex: String,
+        added_pubkeys: Vec<String>,
+        removed_pubkeys: Vec<String>,
+        epoch_after: u64,
+    },
+    /// A pending proposal was stored — call `mls_create_recovery_commit` to
+    /// resolve it before the group stalls (issue #178 #6).
+    NeedsSelfUpdate {
+        group_id_hex: String,
+        reason: String,
+    },
+    /// Catch-all for unprocessable / unhandled results.
+    StateUpdate {
+        kind: String,
+    },
+}
+
+#[derive(uniffi::Record)]
+pub struct FfiPendingWelcome {
+    /// Inner Welcome rumor (kind:444) event id — the lookup key for
+    /// `mls_accept_welcome` / `mls_decline_welcome`.
+    pub welcome_event_id_hex: String,
+    /// Outer NIP-59 gift-wrap (kind:1059) event id — for app-side dedup
+    /// against relay-level caches.
+    pub wrapper_event_id_hex: String,
+    pub group_id_hex: String,
+    pub group_name: String,
+    pub group_description: String,
+    pub group_admin_pubkeys: Vec<String>,
+    pub group_relays: Vec<String>,
+    pub welcomer_pubkey: String,
+    pub member_count: u32,
+    pub is_dm: bool,
 }
 
 // ─── MLS conversion helpers ─────────────────────────────────────────────────
@@ -1517,6 +1673,35 @@ fn core_encrypted_msg_to_ffi(
         tags: data.tags,
         ephemeral_pubkey: data.ephemeral_pubkey,
     }
+}
+
+fn core_pending_welcome_to_ffi(p: nurunuru_core::types::PendingWelcome) -> FfiPendingWelcome {
+    FfiPendingWelcome {
+        welcome_event_id_hex: p.welcome_event_id_hex,
+        wrapper_event_id_hex: p.wrapper_event_id_hex,
+        group_id_hex: p.group_id_hex,
+        group_name: p.group_name,
+        group_description: p.group_description,
+        group_admin_pubkeys: p.group_admin_pubkeys,
+        group_relays: p.group_relays,
+        welcomer_pubkey: p.welcomer_pubkey,
+        member_count: p.member_count,
+        is_dm: p.is_dm,
+    }
+}
+
+/// HKDF-SHA256 over the secret key (hex or nsec) → 32-byte key for
+/// `set_mls_db_key`. `app_salt` scopes the key (e.g. `"io.nurunuru.mdk.v1"`).
+#[uniffi::export]
+pub fn derive_mls_db_key_from_secret(
+    secret_key_hex: String,
+    app_salt: String,
+) -> Result<Vec<u8>, NuruNuruFfiError> {
+    let keys = nostr::Keys::parse(&secret_key_hex)
+        .map_err(|e| NuruNuruFfiError::KeyError(e.to_string()))?;
+    let sk_bytes = keys.secret_key().to_secret_bytes();
+    let key = nurunuru_core::mls::derive_mls_db_key(&sk_bytes, app_salt.as_bytes());
+    Ok(key.to_vec())
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]


### PR DESCRIPTION
![marmot](https://blossom.primal.net/1470d360f8e2f08b203cce54fe5faf4f92b7c1e57437b84b35dea019c65b8bae.png)

Closes #178 by walking through all 11 findings from the MDK-integration review. Every marmot in the colony took a turn auditing the others.

## Core wrapper (rust-engine/nurunuru-core)

- Encrypted MLS DB via SQLCipher (`MdkSqliteStorage::new_with_key`) plus an HKDF-over-secret-key helper for deterministic per-device keys.
- Split the fused `process_welcome` into preview / accept / decline plus `get_pending_welcomes`. Apps can show "Bob invited you" before any crypto state is created, and the user can decline.
- `MlsProcessResult::Commit` now carries the membership delta, computed by diffing members before vs after MDK applies the commit. No more `get_group_info` re-query race.
- `MlsProcessResult::NeedsSelfUpdate` surfaces pending proposals so groups do not stall on the next clean-state operation.
- `accept_pending_welcome` wires up MIP-02 receive-side init-key cleanup. Actual deletion is a TODO until MDK exposes the receive-side accessor; send-side `delete_consumed_key_package_by_hash_ref` already covers the common case.
- Engine exposes `mls_subscribe_welcomes(since)` so iOS and Android stop reinventing their own kind:1059 streams with separate retry, dedup, and gap-fill code.
- Engine exposes `mls_subscribe_keypackage_rotations(contacts)` for a standing kind:30443 watch.
- `MlsManager::new` rejects empty pubkeys; identity is immutable on a manager. A new `mls_reset(new_pubkey)` closes the manager, removes the SQLite file plus WAL/SHM/journal sidecars, and reopens bound to the new identity.

## iOS

- Removed the three unconditional `mlsMergePendingCommit` calls from the receive loop. Merge is now only called after we confirm our own commit was published.
- Removed the `mlsClearPendingCommit` retry block from the receive error path that was tearing down our own in-flight commits and stalling DMs. Receive errors classify as permanent (drop) or retryable (requeue) without touching pending state.
- Stopped publishing the legacy kind:443 KeyPackage mirror on both initial publish and rotation. Read path still accepts kind:443.

## Android

- Stopped publishing kind:443.
- Handles the new `Commit` and `NeedsSelfUpdate` FFI variants; pending proposals enqueue a debounced (once per group per minute) recovery self-update commit.

## Testing

39 Rust tests pass. 11 are new in `tests/issue_178_fixes.rs` covering encrypted DB open / reopen / wrong-key, HKDF determinism, empty-pubkey rejection, `mls_reset` wipe, preview / accept / decline flow, structured commit delta, and the subscription helpers.

## Notes

- Android native `.so` still needs cross-compile plus copy under `rust-engine/nurunuru-ffi/android/libs/` after pulling this branch.
- iOS Xcode build not exercised locally on the build host; Swift surface tracks the regenerated UniFFI types.
- Some manual testing will need to be done

Refs: #178
