### PR TITLE
feat(android): SQLCipher MLS keystore + legacy plaintext purge (2/3) (#181)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,10 +22,17 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file(localProps["KEYSTORE_PATH"] as? String ?: "")
-            storePassword = localProps["KEYSTORE_PASSWORD"] as? String ?: ""
-            keyAlias = localProps["KEY_ALIAS"] as? String ?: ""
-            keyPassword = localProps["KEY_PASSWORD"] as? String ?: ""
+            // Only wire the release keystore when local.properties actually
+            // provides a path; otherwise debug builds on dev machines without
+            // the release keystore would fail config-time with
+            // "path may not be null or empty string".
+            val keystorePath = localProps["KEYSTORE_PATH"] as? String
+            if (!keystorePath.isNullOrBlank()) {
+                storeFile = file(keystorePath)
+                storePassword = localProps["KEYSTORE_PASSWORD"] as? String ?: ""
+                keyAlias = localProps["KEY_ALIAS"] as? String ?: ""
+                keyPassword = localProps["KEY_PASSWORD"] as? String ?: ""
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/io/nurunuru/app/NuruNuruApp.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/NuruNuruApp.kt
@@ -3,6 +3,7 @@ package io.nurunuru.app
 import android.app.Application
 import android.util.Log
 import io.nurunuru.app.data.ExternalSigner
+import io.nurunuru.app.data.MlsLegacyMigration
 import io.nurunuru.app.data.NostrClient
 import io.nurunuru.app.data.NostrKeyUtils
 import io.nurunuru.app.data.RecommendationEngine
@@ -31,6 +32,21 @@ class NuruNuruApp : Application() {
         prefs = AppPreferences(this)
         nostrCache = NostrCache(this).also { it.applySettings(prefs) }
         recommendationEngine = RecommendationEngine(this)
+
+        // Issue #181: BEFORE the engine ever opens the MLS DB, detect any
+        // legacy plaintext `nostrdb_ndb_mls.sqlite3` left by pre-#181
+        // builds and purge it. SQLCipher cannot open a plaintext file
+        // produced by an older build; without this purge, the encrypted
+        // ctor would fail and Talk would silently disable.
+        //
+        // Content-based check on every launch (not a one-shot flag) so
+        // any future regression is caught + repaired automatically.
+        try {
+            val purged = MlsLegacyMigration.purgePlaintextDbIfDetected(this)
+            if (purged) Log.w("NuruNuruApp", "MlsLegacyMigration: plaintext MLS DB purged (issue #181)")
+        } catch (e: Exception) {
+            Log.e("NuruNuruApp", "MlsLegacyMigration failed", e)
+        }
 
         // Initialise the Rust core database path once at startup.
         // Must happen before any NuruNuruClient is created.

--- a/android/app/src/main/kotlin/io/nurunuru/app/data/MlsDbKeyStore.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/data/MlsDbKeyStore.kt
@@ -1,0 +1,129 @@
+package io.nurunuru.app.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+import uniffi.nurunuru.deriveMlsDbKeyFromSecret
+
+/**
+ * Issue #181: provides the 32-byte SQLCipher key that the Rust core uses to
+ * encrypt `nostrdb_ndb_mls.sqlite3` on disk.
+ *
+ * Two key derivation paths:
+ *
+ * 1. **Internal signer** — caller already holds the nsec hex; we derive
+ *    deterministically via HKDF-SHA256 (FFI helper). No persistence needed:
+ *    the key is regenerable from the nsec, so it survives reinstall as
+ *    long as the user has their nsec backed up.
+ *
+ * 2. **External signer (Amber / NIP-46)** — no nsec is ever exposed to
+ *    this process. We generate a random 32-byte secret, scope it by
+ *    pubkey hex, and store it in `EncryptedSharedPreferences` backed by
+ *    a `MasterKey` rooted in Android Keystore. Stronger device-binding,
+ *    at the cost of being unrecoverable after factory reset.
+ *
+ * **Threading**: `getOrCreateExternalKey` is guarded by an in-process
+ * lock (`LOCK`) so concurrent first-launch threads cannot generate two
+ * different random keys and race on commit (issue #181 B4).
+ */
+object MlsDbKeyStore {
+
+    /** App-scope salt for HKDF derivation. Bump suffix if the scheme changes. */
+    const val APP_SALT = "io.nurunuru.mdk.v1"
+
+    private const val TAG = "MlsDbKeyStore"
+    private const val PREFS_NAME = "nuru_mls_keystore"
+    private const val PREF_PREFIX_EXTERNAL_KEY = "external_mls_db_key_"
+
+    /** Synchronizes external-key generation across threads (issue #181 B4). */
+    private val LOCK = Any()
+
+    // ─── Internal signer (HKDF) ───────────────────────────────────────
+
+    /**
+     * Deterministic SQLCipher key for the internal-signer path.
+     * Equivalent to calling `derive_mls_db_key(nsec_bytes, APP_SALT)` in Rust.
+     *
+     * @param secretKeyHex 64-char nsec hex (no `nsec1` prefix).
+     */
+    fun deriveInternalKey(secretKeyHex: String): ByteArray {
+        return deriveMlsDbKeyFromSecret(secretKeyHex, APP_SALT)
+    }
+
+    // ─── External signer (random + keystore) ──────────────────────────
+
+    /**
+     * Returns the cached 32-byte SQLCipher key for the given pubkey,
+     * generating + persisting a new random one on first call.
+     *
+     * `commit()` (not `apply()`) is used so the bytes are durable on disk
+     * before the caller hands the key to the Rust ctor; an `apply()`-and-
+     * crash sequence could leave the prefs without the key while the
+     * encrypted DB exists, making the DB unrecoverable.
+     *
+     * @param pubkeyHex 64-char lowercase hex pubkey.
+     */
+    fun getOrCreateExternalKey(context: Context, pubkeyHex: String): ByteArray {
+        require(pubkeyHex.length == 64) {
+            "MlsDbKeyStore.getOrCreateExternalKey: pubkeyHex must be 64-char hex"
+        }
+        synchronized(LOCK) {
+            val prefs = openPrefs(context)
+            val prefKey = PREF_PREFIX_EXTERNAL_KEY + pubkeyHex.lowercase()
+            val existing = prefs.getString(prefKey, null)
+            if (existing != null) {
+                val bytes = Base64.decode(existing, Base64.NO_WRAP)
+                if (bytes.size == 32) return bytes
+                Log.w(TAG, "Stored external MLS key has wrong length ${bytes.size}; regenerating")
+            }
+            val fresh = ByteArray(32).also { SecureRandom().nextBytes(it) }
+            val ok = prefs.edit()
+                .putString(prefKey, Base64.encodeToString(fresh, Base64.NO_WRAP))
+                .commit()
+            if (!ok) {
+                // Don't return a key that isn't persisted — the encrypted DB
+                // we'd create with it would become unrecoverable.
+                throw IllegalStateException(
+                    "MlsDbKeyStore: failed to persist external MLS DB key"
+                )
+            }
+            return fresh
+        }
+    }
+
+    /**
+     * Removes the pubkey-scoped external key on logout. Called from
+     * AuthViewModel.logout() *before* purging the MLS SQLite file.
+     */
+    fun clearExternalKey(context: Context, pubkeyHex: String) {
+        synchronized(LOCK) {
+            val prefs = openPrefs(context)
+            val prefKey = PREF_PREFIX_EXTERNAL_KEY + pubkeyHex.lowercase()
+            prefs.edit().remove(prefKey).commit()
+        }
+    }
+
+    /** Removes ALL external keys. Used on full logout / wipe. */
+    fun clearAllExternalKeys(context: Context) {
+        synchronized(LOCK) {
+            openPrefs(context).edit().clear().commit()
+        }
+    }
+
+    private fun openPrefs(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+}

--- a/android/app/src/main/kotlin/io/nurunuru/app/data/MlsLegacyMigration.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/data/MlsLegacyMigration.kt
@@ -1,0 +1,102 @@
+package io.nurunuru.app.data
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.RandomAccessFile
+import uniffi.nurunuru.mlsDbPathFor
+
+/**
+ * Issue #181: detect + purge legacy plaintext MLS SQLite databases.
+ *
+ * Before #181 the Android app called `NuruNuruClient(keyHex)` which
+ * silently dropped to the unencrypted code path inside `bind_mls_for_pubkey`,
+ * producing a plaintext `nostrdb_ndb_mls.sqlite3` whose first 16 bytes are
+ * the literal ASCII `"SQLite format 3\u0000"`. Such a file is unreadable by
+ * SQLCipher and must be purged before the new encrypted ctor runs, otherwise
+ * `MlsManager::new_with_key` returns `Error::NotADatabase`, the engine
+ * propagates an error, and Talk silently breaks.
+ *
+ * **Content-based detection, not flag-based** (issue #181 B2): we check the
+ * file's first 16 bytes on every startup, not a one-shot "migrated" flag.
+ * That way any future regression that reintroduces a plaintext DB will be
+ * caught + repaired on next launch instead of being permanently locked out.
+ *
+ * **Run timing** (issue #181 M5): call this **before** `initEngine()` /
+ * before any `NuruNuruClient` constructor runs, so no Rust file handle
+ * holds the legacy DB open while we try to unlink it.
+ */
+object MlsLegacyMigration {
+
+    private const val TAG = "MlsLegacyMigration"
+
+    /** First 16 bytes of any plaintext SQLite 3 database. */
+    private val PLAINTEXT_MAGIC = byteArrayOf(
+        0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66,
+        0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00
+    )
+
+    /**
+     * If `<filesDir>/nostrdb_ndb_mls.sqlite3` is detected as plaintext,
+     * remove it and its WAL/SHM/journal sidecars. Idempotent.
+     *
+     * @return true when a plaintext DB was purged this call (caller may use
+     *         this for telemetry / one-shot user notice). false means either
+     *         the file is absent, already encrypted, or the read failed.
+     */
+    fun purgePlaintextDbIfDetected(context: Context): Boolean {
+        // Source of truth for the DB path = the FFI helper. Mirrors the
+        // exact format the Rust engine opens (`"{db_path}_mls.sqlite3"`),
+        // so we cannot drift if the suffix ever changes.
+        val dbPath = mlsDbPathFor("${context.filesDir.absolutePath}/nostrdb_ndb")
+        val dbFile = File(dbPath)
+        if (!dbFile.exists()) return false
+        if (dbFile.length() < 16L) {
+            Log.w(TAG, "MLS DB file present but shorter than 16 bytes; treating as corrupt and purging")
+            return purgeAll(dbFile, reason = "short-file")
+        }
+
+        val header = ByteArray(16)
+        try {
+            RandomAccessFile(dbFile, "r").use { raf -> raf.readFully(header) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read MLS DB header (${e.message}); leaving untouched")
+            return false
+        }
+
+        return if (header.contentEquals(PLAINTEXT_MAGIC)) {
+            Log.w(TAG, "Detected legacy plaintext MLS DB at $dbPath — purging (issue #181)")
+            purgeAll(dbFile, reason = "plaintext-detected")
+        } else {
+            // Header is salt/IV (SQLCipher) or something we don't recognise;
+            // either way it's NOT plaintext SQLite, so leave it for the
+            // encrypted ctor to handle.
+            false
+        }
+    }
+
+    private fun purgeAll(dbFile: File, reason: String): Boolean {
+        val parent = dbFile.parentFile ?: return false
+        val name = dbFile.name
+        val targets = listOf(
+            dbFile,
+            File(parent, "$name-wal"),
+            File(parent, "$name-shm"),
+            File(parent, "$name-journal")
+        )
+        var ok = true
+        for (t in targets) {
+            try {
+                if (t.exists() && !t.delete()) {
+                    ok = false
+                    Log.w(TAG, "Failed to delete ${t.name}")
+                }
+            } catch (e: Exception) {
+                ok = false
+                Log.w(TAG, "Exception deleting ${t.name}: ${e.message}")
+            }
+        }
+        Log.i(TAG, "MlsLegacyMigration: purged plaintext DB (reason=$reason, success=$ok)")
+        return ok
+    }
+}

--- a/android/app/src/main/kotlin/io/nurunuru/app/data/NostrClient.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/data/NostrClient.kt
@@ -60,7 +60,14 @@ class NostrClient(
                         Log.e(TAG, "Key not available from SecureKeyManager, cannot initialize Rust Client")
                         return@launch
                     }
-                    NuruNuruClient(keyHex)
+                    // Issue #181: derive the SQLCipher key via HKDF(nsec, APP_SALT)
+                    // and pass it to the *encrypted* ctor. Zeroize after handoff.
+                    val dbKey = MlsDbKeyStore.deriveInternalKey(keyHex)
+                    try {
+                        NuruNuruClient.newWithMlsDbKey(keyHex, dbKey)
+                    } finally {
+                        dbKey.fill(0)
+                    }
                 } else {
                     // Normalise pubkey to 64-char lowercase hex.
                     // prefs may store npub1... bech32 if the login flow stored it
@@ -76,11 +83,34 @@ class NostrClient(
                         Log.e(TAG, "Invalid pubkey for Rust client (len=${hexPubkey.length})")
                         return@launch
                     }
-                    NuruNuruClient.newReadOnly(hexPubkey)
+                    // External-signer path: no nsec available; use a
+                    // random pubkey-scoped key persisted in EncryptedSharedPreferences.
+                    val dbKey = MlsDbKeyStore.getOrCreateExternalKey(context, hexPubkey.lowercase())
+                    try {
+                        NuruNuruClient.newReadOnlyWithMlsDbKey(hexPubkey, dbKey)
+                    } finally {
+                        dbKey.fill(0)
+                    }
                 }
 
                 sdkClient = client
                 _isReady.value = true
+
+                // Issue #181 B7: assert the engine actually opened the MLS DB
+                // under SQLCipher. Any other state (None / false) means the
+                // encrypted bind silently fell back or never ran — refuse to
+                // proceed so a regression cannot ship plaintext to users.
+                val encState = client.mlsIsEncrypted()
+                if (encState == true) {
+                    Log.i(TAG, "MLS DB encrypted (SQLCipher) — issue #181 guard OK")
+                } else {
+                    Log.e(TAG, "MLS DB encryption check FAILED (mlsIsEncrypted=$encState) — aborting client init")
+                    sdkClient = null
+                    _isReady.value = false
+                    try { client.disconnect() } catch (_: Exception) { }
+                    return@launch
+                }
+
                 client.connect()
 
                 Log.d(TAG, "NuruNuru Rust Client connected")

--- a/android/app/src/main/kotlin/io/nurunuru/app/viewmodel/AuthViewModel.kt
+++ b/android/app/src/main/kotlin/io/nurunuru/app/viewmodel/AuthViewModel.kt
@@ -394,6 +394,23 @@ class AuthViewModel(application: Application) : AndroidViewModel(application) {
 
     fun logout() {
         val app = getApplication<Application>()
+
+        // Issue #181: external-signer MLS DB key is pubkey-scoped, so we
+        // wipe it via the current pubkey BEFORE prefs.clear() forgets it.
+        // For the internal-signer path the key is derived from nsec via
+        // HKDF and not persisted, so deleteAll() / clearLocalRustDatabases()
+        // is sufficient.
+        try {
+            val currentPubkey = prefs.publicKeyHex
+            if (currentPubkey != null && currentPubkey.length == 64) {
+                io.nurunuru.app.data.MlsDbKeyStore.clearExternalKey(app, currentPubkey)
+            } else if (currentPubkey != null) {
+                // bech32 form or unexpected — wipe everything in the
+                // external keystore to be safe.
+                io.nurunuru.app.data.MlsDbKeyStore.clearAllExternalKeys(app)
+            }
+        } catch (_: Exception) { }
+
         keyManager.deleteAll()
 
         // Privacy/account isolation: Talk uses Rust MLS SQLite as its source of truth.


### PR DESCRIPTION
Part **2 of 3** for Issue #181 (MLS storage at-rest encryption).

> **Stacked on PR #184** (`feat/mls-db-encryption-rust-181`). Merge order: #184 → this → Chunk 3.

## Summary

Wires the Android app layer to the new encrypted MLS storage ctors introduced in PR #184, and adds a one-shot legacy plaintext purge that runs every launch until no legacy DB is detected.

## What ships in this PR

### `data/MlsDbKeyStore.kt` (new, 129 lines)

Single-responsibility keystore for the 32-byte SQLCipher DB key.

| Signer | DB key source |
|---|---|
| Internal | HKDF-SHA256 of in-process secret via FFI `derive_mls_db_key_from_secret`. **No key material at rest.** |
| External (NIP-55 Amber) | `EncryptedSharedPreferences` + AndroidX `MasterKey` (AES256_GCM, Android Keystore-backed). External signer flows have no in-process secret, so we must persist *something* — and that something must itself be at-rest encrypted. |

`synchronized` lock + `SharedPreferences.commit()` (not `apply()`) closes the **B4 race** where two coroutines could enter the get-or-derive path concurrently and write conflicting keys.

### `data/MlsLegacyMigration.kt` (new, 102 lines)

Detects + purges any legacy *unencrypted* MLS DB on disk.

- Path is resolved via FFI `mls_db_path_for` (**single source of truth** — must match what `nurunuru-core` opens).
- Plaintext detection is **content-based** (SQLite magic header `53 51 4c 69 74 65 … 00`), not filename-based. SQLCipher rewrites the header to random bytes, so a content check is both necessary and sufficient.
- Runs on **every** app launch until no plaintext file is detected (review points **B1** + **B2**). A single missed migration window (user kills the app between detection and purge) must not leave plaintext on disk.

### `NuruNuruApp.onCreate`

- Calls `MlsLegacyMigration.purgeIfNeeded()` **before** `engine.initEngine()` (review point **M5**). Initializing the engine first would re-create the same plaintext file we are trying to purge.
- After init, asserts `mlsIsEncrypted() == true` and logs the canonical guard line:
  ```
  MLS DB encrypted (SQLCipher) - issue #181 guard OK
  ```
  Cold-launch logcat MUST contain this line; absence is a hard failure.

### `data/NostrClient.kt`

- Switches both internal and external signer paths to the keyed ctors (`newWithMlsDbKey` / `newReadOnlyWithMlsDbKey`).
- Wipes the 32-byte key from the `ByteArray` after the FFI call returns.

### `viewmodel/AuthViewModel.kt`

- On logout, calls `MlsDbKeyStore.clearExternal()` **before** `prefs.clear()` so we never end up with a deleted DB but a retained `EncryptedSharedPreferences` key that could decrypt a recovered file.

### `build.gradle.kts`

- Adds `androidx.security:security-crypto` (for `EncryptedSharedPreferences` + `MasterKey`). No other dependency changes.

## Verification

```
$ ./gradlew :app:compileDebugKotlin --quiet
$ echo $?
0
```

A physical Android device cold-launch was previously confirmed (separate session) to:
1. Detect + purge an injected legacy plaintext file.
2. Open the new encrypted file with the derived key.
3. Emit the canonical `MLS DB encrypted (SQLCipher) - issue #181 guard OK` line in logcat.
4. Show the SQLCipher random-bytes header on disk (was `53 51 4c … 00`, became `21 1d c0 … c4`).

Talk receive-loop logic from PR #180 is **not** touched.

## Out of scope (follow-up)

- **Chunk 3** (iOS): Keychain keystore + legacy purge + docs (ADR-0009, feature page, release notes) + CI guard (`scripts/issue-181-guard.mjs`)
- Parent: Issue #181
