### PR TITLE
feat(ios): SQLCipher MLS keystore + legacy purge + docs + CI guard (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (Android / iOS / Rust core) — Issue #181
+
+- Marmot / MDK の MLS DB (`*_mls.sqlite3`) を **SQLCipher 4 で暗号化** するよう変更しました。これまで端末ディスク上に **平文で書かれていた MLS の署名鍵 / 暗号鍵 / epoch key pair / KeyPackage 秘密素材** がディスク窃取で抜けるリスクを塞ぐ修正です。
+- DB 鍵の取り扱い:
+  - 自分の nsec をアプリ内保持する内部署名モード: nsec から HKDF-SHA256 で **デバイス決定論的に派生** (`derive_mls_db_key`)、永続保存は無し。
+  - 外部署名モード (Android Amber / iOS NIP-46 bunker) では、nsec を持たないため **32 byte 乱数を端末に紐づいた安全領域に保存**:
+    - Android: `EncryptedSharedPreferences` (AES256-GCM, MasterKey)。
+    - iOS: Keychain `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`、サービス `io.nurunuru.app.mls`、`isExcludedFromBackup` を MLS DB / WAL / SHM に付与し iCloud / iTunes バックアップから除外。
+- 起動時にコンテンツベースで旧平文 DB を検出し自動 purge する `MlsLegacyMigration` を Android / iOS 双方に追加。WAL / SHM / journal サイドカーも一緒に削除します。
+- FFI に `mls_is_encrypted()` を追加し、暗号化されていなければ起動を hard-fail させる guard を `NostrClient.connect()` (Android) と `NuruNuruFFILiveClient.assertEncrypted()` (iOS) に挟みました。ログには `MLS DB encrypted (SQLCipher) — issue #181 guard OK` が必ず出ます。
+- CI lint guard `npm run lint:issue-181` を追加し、unkeyed な `NuruNuruClient(secretKeyHex:)` / `newReadOnly(pubkeyHex:)` の再導入を block します。
+- 詳細: [`docs/wiki/features/mls-db-encryption.md`](docs/wiki/features/mls-db-encryption.md) / [`docs/wiki/decisions/adr-0009-mls-db-encryption.md`](docs/wiki/decisions/adr-0009-mls-db-encryption.md)
+
+### Upgrade notes — Issue #181
+
+**⚠️ アップグレード時に Talk グループの暗号状態 (MLS state) が一度クリアされ、過去のメッセージ履歴は復号できなくなります。** 旧バージョンの平文 DB はセキュリティ上残せないため、起動時に自動削除されるためです。
+
+- アップグレード後の挙動:
+  - 既存のグループ ID は relay 側にあるため一覧自体は見えます。
+  - グループ内の過去メッセージは復号できません。新規メッセージから順に表示されます。
+  - 既存メンバーが KeyPackage rotation を待たずに会話を継続するには、グループから再招待を受ける必要があります。
+- KeyPackage 鍵自体は新規 SQLCipher DB で再生成・再 publish されます (`publishKeyPackage: published kind=30443`)。
+- 平文 DB が存在しないクリーンインストールでは影響ありません。
+- npub / nsec 自体には影響ありません — それらは引き続き旧来どおり Keychain / EncryptedSharedPreferences に保存されています。
+
+### Known issues (Talk — separate from #181)
+
+- iOS の MDK epoch が Android より先行している既存環境では、iOS が送った kind:445 メッセージが Android 側で `state_not_ready` として retry queue に滞留することがあります (PR #180 由来の MDK 振る舞いで、Issue #181 の暗号化対応とは独立)。Android で Talk タブを開き直すか、グループを再選択することで `fetchMlsMessages` の `repairFull` 経路が走り、追従できる場合があります。継続調査中。
+
 ## [1.5.0] - 2026-05-17
 
 ### Added (Web)

--- a/docs/release-notes/issue-181-mls-db-encryption.md
+++ b/docs/release-notes/issue-181-mls-db-encryption.md
@@ -1,0 +1,95 @@
+# Release notes — Issue #181 MLS DB encryption
+
+This file contains the short-form release notes intended for:
+
+- GitHub release body (`gh release create`)
+- zapstore release notes (`~/go/bin/zsp publish`)
+- Google Play "What's new in this version"
+- App Store "What's New" / TestFlight build notes
+
+Copy the relevant section verbatim — do not edit per channel unless a length
+limit applies.
+
+---
+
+## Short form (GitHub / zapstore — JP)
+
+🔒 セキュリティ修正 (Issue #181)
+
+Marmot (MLS) のローカル DB を SQLCipher で暗号化しました。これまで端末ディスク上に
+平文で書かれていた MLS の署名鍵 / 暗号鍵 / KeyPackage 秘密素材が、ディスク窃取で
+抜けるリスクを塞ぐ修正です。
+
+⚠️ 初回起動時に旧 MLS DB は自動削除されます。
+- 既存の Talk グループの **過去メッセージは復号できなくなります**。
+- グループ一覧自体と新規メッセージは引き続き使えます。
+- 過去会話の継続が必要な場合は、グループから再招待してもらってください。
+- npub / nsec / 通常の Nostr 投稿には一切影響ありません。
+
+クリーンインストールの方は影響ありません。
+
+---
+
+## Short form (GitHub / zapstore — EN)
+
+🔒 Security fix (Issue #181)
+
+The Marmot (MLS) local database is now encrypted with SQLCipher. Previously the
+MLS signature keys, encryption keys, and KeyPackage private material were
+written to disk in plaintext and could be exfiltrated by anyone with physical
+or backup access to the device.
+
+⚠️ The legacy plaintext MLS DB is purged automatically on first launch:
+- Past messages in existing Talk groups will no longer be decryptable.
+- Group lists and new messages continue to work.
+- To continue a past conversation, ask to be re-invited to the group.
+- Your npub / nsec / regular Nostr notes are unaffected.
+
+Clean installs are unaffected.
+
+---
+
+## Long form (CHANGELOG.md pointer)
+
+See [`CHANGELOG.md`](../../CHANGELOG.md) `[Unreleased] > Security` and
+`Upgrade notes` sections for the full technical changelog, including:
+
+- Key derivation strategy (HKDF-SHA256 for internal signer / random 32-byte
+  for external signer)
+- Per-platform secure storage (Android EncryptedSharedPreferences /
+  iOS Keychain `…ThisDeviceOnly`)
+- Content-based legacy purge (`MlsLegacyMigration`)
+- Hard-fail guard (`mls_is_encrypted()` + `assertEncrypted()`)
+- CI lint guard (`npm run lint:issue-181`)
+
+---
+
+## Per-platform release matrix
+
+| Channel | Distributed artifact | Notes |
+|---|---|---|
+| zapstore | `nurunuru-X.Y.Z-arm64-v8a.apk` | Use JP short form above. |
+| GitHub Release | Same APK + `.aab` + iOS `.ipa` (if shipping to TestFlight) | Use JP + EN short forms. |
+| Google Play | `app-release.aab` | Use JP short form, truncate to 500 chars if needed. |
+| App Store / TestFlight | `NuruNuru.ipa` | Use EN short form. App Review may ask about the data migration — point them to this file + CHANGELOG.md. |
+
+---
+
+## Talker-facing FAQ (for support replies)
+
+**Q: アップデートしたら Talk グループの過去メッセージが見えなくなった。バグですか？**
+A: いいえ、Issue #181 の暗号化対応に伴う仕様変更です。旧バージョンは MLS の鍵を
+平文で保存していたため、新バージョンで暗号化形式に切り替える際に旧 DB を安全に
+削除する必要がありました。新しいグループ・新しいメッセージは引き続き使えます。
+
+**Q: 過去会話を取り戻せますか？**
+A: 端末側の MLS state は復元できませんが、グループのメンバーに再招待してもらえば
+新しい鍵で同じグループ ID に再参加でき、それ以降の会話は通常通り継続できます。
+
+**Q: npub や投稿は消えていない？**
+A: 消えていません。Issue #181 は MLS 専用の DB に限定された変更です。Nostr の
+通常投稿・プロフィール・フォロー・通知・タイムライン履歴には一切影響ありません。
+
+**Q: 自分の KeyPackage はどうなりますか？**
+A: 起動時に新しい SQLCipher DB 上で再生成され、リレーに再 publish されます。
+他のユーザーから新しく招待を受ける動作には影響ありません。

--- a/docs/wiki/decisions/adr-0009-mls-db-encryption.md
+++ b/docs/wiki/decisions/adr-0009-mls-db-encryption.md
@@ -1,0 +1,153 @@
+# ADR-0009: MLS storage DB is encrypted at rest with SQLCipher
+
+## Status
+
+`Accepted` (2026-05-22) — Android verified live on device, iOS bindings + build succeeded.
+
+## Context
+
+Issue #181 reported that the Marmot MLS SQLite storage was plaintext on
+disk on both Android and iOS. The file (`nostrdb_ndb_mls.sqlite3` on
+Android, `nurunuru_ndb_mls.sqlite3` on iOS) contained:
+
+- MLS signature keys (long-term group identity)
+- MLS encryption keys (current epoch)
+- Epoch key pairs (forward secrecy state)
+- Pending KeyPackages (used to invite a new identity into existing groups)
+
+Anyone with file-system access — rooted/jailbroken device, USB backup
+extraction, or forensic image of the device — could read all group
+material and impersonate any of the user's MLS identities going forward.
+
+The pre-#181 code path went through `NuruNuruClient(secretKeyHex:)` (and
+`newReadOnly(pubkeyHex:)` on the external-signer path). Internally
+`bind_mls_for_pubkey` silently dropped to the unencrypted code path when
+no key had been set, so there was no startup-time error to surface in UI.
+
+The fix has to satisfy:
+
+- No forensic recovery of key material from the device after-the-fact.
+- Continued ability for users to back up their identity via the **nsec**
+  alone (no extra key material the user has to manage).
+- For external signers (Amber / NIP-46 bunker) where the nsec is never
+  exposed to this process, a different derivation strategy is needed.
+- Backwards compatibility: existing installs have a plaintext DB on disk
+  that the new SQLCipher ctor cannot open (header mismatch).
+
+## Decision
+
+1. **Encrypt the MLS SQLite DB with SQLCipher 4.x** using a 32-byte raw
+   key supplied at engine bind time. `cipher_compatibility = 4`,
+   `temp_store = MEMORY`. Key transport from app → Rust via FFI as 32
+   bytes; engine validates length before SQLCipher bind.
+
+2. **Two derivation paths**:
+   - **Internal signer** (app holds nsec): deterministic HKDF-SHA256 over
+     the nsec with `info = "mdk-sqlite-db-key"` and
+     `salt = "io.nurunuru.mdk.v1"`. No additional persistence — the key
+     is regenerable from the nsec.
+   - **External signer** (Amber on Android, NIP-46 bunker on iOS): random
+     32 bytes via `SecRandomCopyBytes` / `SecureRandom`, scoped by pubkey
+     hex, persisted in Keychain
+     (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`) on iOS or
+     `EncryptedSharedPreferences` rooted in Android Keystore on Android.
+
+3. **Engine refuses to silently degrade**: when the caller supplied a key
+   and SQLCipher bind fails, `bind_mls_for_pubkey` returns hard error
+   instead of `mls = None`. FFI exposes `mls_is_encrypted() -> Option<bool>`
+   and the app refuses to expose an `MlsFFIBridge` unless this returns
+   `Some(true)` after construction.
+
+4. **Legacy plaintext DBs are auto-purged** on every launch via
+   content-based detection (`"SQLite format 3\u0000"` magic match), not a
+   one-shot migration flag. Path is routed through FFI `mls_db_path_for()`
+   so Kotlin / Swift cannot drift from the engine's path format.
+
+5. **Backup-safe by default**: Android external-key prefs file excluded
+   from Auto Backup via `backup_rules.xml`. iOS DB + WAL + SHM marked
+   `isExcludedFromBackup`. Keychain entries on iOS are `ThisDeviceOnly`.
+
+6. **Key buffer zeroization** after FFI hand-off: Swift via
+   `Data.resetBytes(in:)` taken `inout` (the previous `var z = bytes`
+   pattern is a no-op copy); Kotlin via `dbKey.fill(0)` in `finally`.
+
+## Alternatives Considered
+
+- **`SQLITE_HAS_CODEC` via SEE (proprietary)**: rejected — not
+  open-source, license cost, distribution friction.
+- **Whole-DB encryption at the FS layer (CryptKeeper / iOS Data
+  Protection only)**: rejected — `NSFileProtectionComplete` would lock
+  out background MLS message processing while device is locked, and
+  Android's FBE depends on user PIN policy we cannot rely on.
+- **Argon2id over a user-chosen passphrase**: rejected for v1 — UX cost
+  (user must remember a separate password); SQLCipher's PBKDF2 is
+  bypassed when raw 32-byte keys are supplied which is acceptable because
+  the input is already high-entropy (HKDF output or CSPRNG).
+- **One key for all accounts**: rejected — leaks group membership across
+  identities on a shared device; pubkey-scoped keys are mandatory.
+- **Flag-based migration ("ran_v1_purge=true" in prefs)**: rejected
+  (issue #181 B2). A future regression that reintroduces plaintext can't
+  be auto-detected; users would be silently locked out. Content-based
+  detection on every launch is idempotent and self-healing.
+
+## Why this fits NuruNuru
+
+- Maps to [[../culture/principles|五箇条]] "鍵を守る" — private key
+  material and group identity state must never be readable off-device.
+- Maps to [[../culture/four-freedoms|プライバシーの自由]] — Talk groups
+  are end-to-end encrypted on the wire; storing them in cleartext on
+  disk negates that guarantee.
+- Aligns with [[../culture/not-doing|やらないことリスト]] item "鍵を
+  process 外に出さない" — external-signer keys never enter Keychain in
+  cleartext on the wire; they're random 32-byte values generated locally
+  and bound to the device.
+
+## Consequences
+
+**Good:**
+- All MLS key material is encrypted at rest with a 32-byte key derived
+  per-account.
+- Legacy plaintext DBs are auto-detected and purged — no manual user
+  action required.
+- Engine guard rail (`mls_is_encrypted()` assertion) prevents future
+  regressions from silently disabling encryption.
+- Threat surface shrinks meaningfully on lost/stolen devices.
+
+**Bad / technical debt:**
+- External-signer users (Amber / NIP-46) will lose their MLS group state
+  on factory reset or reinstall — the device-bound random key is gone.
+  This must be communicated in release notes (issue #181 M6 — pending).
+- One-time data loss for all existing users on the first patched build —
+  the plaintext DB is purged, MLS groups must be rejoined via fresh
+  Welcomes. Documented in CHANGELOG (pending).
+- HKDF(nsec) path means that anyone who obtains the nsec can decrypt the
+  DB forever (no forward secrecy of disk state across nsec compromise).
+  This is consistent with the rest of the app — the nsec already grants
+  full identity control — but worth restating in the threat model.
+- iOS Keychain `…ThisDeviceOnly` accessibility means the key is
+  unavailable in the brief window between boot and first unlock. App
+  layer must defer `ensureMlsClient()` until after first unlock, which
+  matches current lazy-init semantics.
+
+**Future revisit triggers:**
+- MDK upstream adopts a different storage encryption scheme.
+- Users complain about losing groups on reinstall → consider an optional
+  user-managed backup blob (exported HKDF-derivable key alongside nsec).
+- A second high-value secret moves into the same SQLite DB (e.g.
+  bookmarks state) — may want to split DBs by sensitivity tier.
+
+## Source references
+
+- `rust-engine/nurunuru-core/src/mls.rs`
+- `rust-engine/nurunuru-core/src/engine.rs`
+- `rust-engine/nurunuru-ffi/src/lib.rs`
+- `rust-engine/nurunuru-napi/src/lib.rs`
+- `android/app/src/main/kotlin/io/nurunuru/app/data/MlsDbKeyStore.kt`
+- `android/app/src/main/kotlin/io/nurunuru/app/data/MlsLegacyMigration.kt`
+- `ios/NuruNuru/Data/MlsDbKeyStore.swift`
+- `ios/NuruNuru/Data/MlsLegacyMigration.swift`
+- `ios/NuruNuru/Data/NuruNuruFFILiveClient.swift`
+- [[../features/mls-db-encryption]]
+- [[adr-0002-native-talk-uses-marmot-mls]]
+- [[adr-0003-ios-external-signing-uses-nip46]]
+- GitHub issue `tami1A84/null--nostr#181`

--- a/docs/wiki/features/mls-db-encryption.md
+++ b/docs/wiki/features/mls-db-encryption.md
@@ -1,0 +1,183 @@
+# MLS DB Encryption (Issue #181)
+
+## Summary
+
+The Marmot MLS storage SQLite database (`<filesDir>/nostrdb_ndb_mls.sqlite3`
+on Android, `<AppSupport>/nurunuru_ndb_mls.sqlite3` on iOS) is encrypted
+with **SQLCipher 4.x** using a 32-byte raw key. Before issue #181 this DB
+was plaintext on disk; signature keys, encryption keys, epoch key pairs,
+and KeyPackages were readable to anyone with file-system access (rooted /
+jailbroken device, USB backup, forensic image).
+
+## Current behavior
+
+### Key material
+
+- **32-byte raw key** passed to SQLCipher via `PRAGMA key = "x'<64-hex>';"`.
+- `cipher_compatibility = 4`, `temp_store = MEMORY` (set by MDK).
+- Two derivation paths, selected by signer type:
+
+| Signer | Derivation | Persistence | Recovery |
+|---|---|---|---|
+| Internal (nsec held by app) | HKDF-SHA256 over the nsec, info=`"mdk-sqlite-db-key"`, salt=`"io.nurunuru.mdk.v1"` | none (regenerable) | Survives reinstall as long as the user has their nsec backed up. |
+| External (Amber / NIP-46) | `SecRandomCopyBytes` / `SecureRandom` 32 bytes, scoped by pubkey hex | Android: `EncryptedSharedPreferences` + `MasterKey` (AES256_GCM); iOS: Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` | Lost on factory reset / app reinstall — keys are device-bound by design. |
+
+### Engine guard rails
+
+- `NuruNuruClient::new_with_mls_db_key()` / `new_read_only_with_mls_db_key()`
+  validate the key is exactly 32 bytes before binding.
+- `bind_mls_for_pubkey()` returns hard error (not silent `mls = None`) when
+  the caller supplied a key and SQLCipher bind fails (issue #181 B5).
+- FFI exposes `mls_is_encrypted() -> Option<bool>` so the app layer can
+  assert encryption state at runtime (issue #181 B7).
+- Both `MlsFFILiveClient` (iOS) and Android `NostrClient` call this guard
+  immediately after the encrypted ctor and refuse to expose an
+  `MlsFFIBridge` when the state is not `true` — Talk surfaces an error
+  instead of "groups are empty".
+
+### Legacy migration
+
+Pre-#181 builds wrote a plaintext SQLite DB with the magic header
+`"SQLite format 3\u0000"` (ASCII, 16 bytes). On every launch the migration
+runs **before** `init_engine()`:
+
+1. Resolves the canonical DB path via FFI `mls_db_path_for(db_path)` — the
+   only source of truth. The suffix format `"{db_path}_mls.sqlite3"` is
+   never reproduced in Kotlin or Swift (issue #181 B1).
+2. Reads the file's first 16 bytes (content-based, not flag-based, so any
+   future regression is auto-repaired on next launch — issue #181 B2).
+3. If the header matches the plaintext magic, purges the DB and its
+   `-wal` / `-shm` / `-journal` sidecars.
+4. If the header is SQLCipher salt/IV, leaves it for the encrypted ctor.
+
+### Backup posture
+
+- **Android**: external-signer key prefs file (`nuru_mls_keystore`) is
+  excluded from Auto Backup via
+  `android/app/src/main/res/xml/backup_rules.xml` (issue #181 B6). Without
+  this, prefs could be restored to a new device where Keystore master key
+  is absent → permanent unreadable backup.
+- **iOS**: the MLS DB + WAL + SHM are marked
+  `URLResourceValues.isExcludedFromBackup = true` after the encrypted ctor
+  succeeds (`MlsLegacyMigration.excludeMlsDbFromBackup`). Keychain entries
+  use `…ThisDeviceOnly` so they are never iCloud-backed either.
+
+### Logout / key disposal
+
+- `AuthViewModel.logout()` clears the per-pubkey external key from
+  Keychain / EncryptedSharedPreferences **before** clearing
+  `prefs.publicKeyHex` (otherwise we lose the scope key). Internal-signer
+  path requires no explicit removal — `SecureKeyManager.deleteAll()` /
+  `prefs.clear()` drops the nsec which is the root secret.
+- In Swift, the key buffer is zeroized via `Data.resetBytes(in:)` taken by
+  `inout` from `MlsDbKeyStore` through `MlsFFILiveClient` — the previous
+  pattern of `var z = bytes` was a no-op copy (issue #181 B3).
+- In Kotlin, `dbKey.fill(0)` runs in a `finally` block after FFI hand-off.
+
+## Platform notes
+
+| Concern | Android | iOS |
+|---|---|---|
+| DB path | `<filesDir>/nostrdb_ndb_mls.sqlite3` | `<AppSupport>/nurunuru_ndb_mls.sqlite3` |
+| External-key store | `EncryptedSharedPreferences` (`nuru_mls_keystore`) | Keychain service `io.nurunuru.app.mls` |
+| Backup exclusion | `backup_rules.xml` | `isExcludedFromBackup` + `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` |
+| Migration entry point | `NuruNuruApp.onCreate()` (before `initEngine`) | `NostrRepository.ensureMlsClient()` (before `initEngine`, lazy) |
+| Concurrency guard | `synchronized(LOCK)` + `commit()` (not `apply()`) | `NSLock` + Keychain `kSecMatchLimitOne` write |
+| Logout cleanup | `MlsDbKeyStore.clearExternalKey(...)` before `prefs.clear()` | `MlsDbKeyStore.clearExternalKey(pubkeyHex:)` before `prefs.clear()` |
+| Zeroize after FFI | `dbKey.fill(0)` in `finally` | `Data.resetBytes(in:)` via `inout` |
+
+Desktop (`nurunuru-napi`) also exposes `create_with_mls_db_key()` +
+`mls_is_encrypted()` (issue #181 M1); the legacy unkeyed ctor remains
+only as a deprecated compatibility surface.
+
+## Threat model
+
+| Adversary | Internal-signer (HKDF) | External-signer (random + keystore) |
+|---|---|---|
+| Casual file-system read on rooted/JB device | Blocked (SQLCipher) | Blocked (SQLCipher) |
+| USB backup / forensic image of disk | Blocked (key not in disk image) | Blocked (key in Keychain/Keystore, not in backup) |
+| Compromised nsec (e.g. user pasted to phishing site) | DB readable from any clone of the nsec | DB still bound to the lost device — attacker cannot reuse on another device |
+| Factory reset | Recoverable from nsec backup | Permanently lost (by design) |
+| iCloud / Google account compromise | Same as nsec exposure (DB regenerable) | Keys never leave the device — not in cloud backup |
+
+The internal-signer path inherits the nsec's threat profile: easy
+recoverability at the cost of "anyone with the nsec can decrypt the DB
+forever". The external-signer path is strictly device-bound by design —
+this matches the user model where the nsec never enters the app
+(`AGENTS.md`: "Private keys: Keychain only…").
+
+## Verification
+
+A physical Android device was used to verify the encrypted ctor
+runtime behavior:
+
+```text
+W/MlsLegacyMigration: Detected legacy plaintext MLS DB ... purging (issue #181)
+I/MlsLegacyMigration: purged plaintext DB (reason=plaintext-detected, success=true)
+I/NostrClient: MLS DB encrypted (SQLCipher) — issue #181 guard OK
+```
+
+The DB header changed from the plaintext magic
+`53 51 4c 69 74 65 20 66 6f 72 6d 61 74 20 33 00` to SQLCipher random bytes
+`21 1d c0 1b 59 f1 4a af 49 94 af 6c dd 30 26 c4`. File size preserved at
+258,048 bytes.
+
+iOS xcodebuild for `iPhone 17` simulator returns `BUILD SUCCEEDED` with
+the new `MlsDbKeyStore.swift`, `MlsLegacyMigration.swift`, the updated
+`MlsFFILiveClient` encrypted inits, and the `MlsFFIBridge.mlsIsEncrypted()`
+protocol extension. Runtime device verification is the next step.
+
+## Open questions
+
+- **CI guard** (issue #181 M2): implemented as `scripts/issue-181-guard.mjs`
+  (run via `npm run lint:issue-181`). Walks `ios/NuruNuru/` and
+  `android/app/src/main/kotlin/` and fails on any reintroduction of the
+  unkeyed `NuruNuruClient(secretKeyHex:)` or `NuruNuruClient.newReadOnly(pubkeyHex:)`
+  ctors. Skips generated UniFFI bindings under `bindgen/`. Verified by
+  negative test (inject 2 violations → 2 reported, exit non-zero) and
+  positive sweep (214 files, 141 596 pattern checks, 0 violations on the
+  clean tree).
+- **Settings UI** (issue #181 M4): deliberately not shipped. Decision noted
+  in the v1.5 cycle — exposing an "encrypted ✓" indicator adds UI noise
+  without giving the user an actionable signal; the runtime guard already
+  hard-fails if the DB is ever unencrypted, so a green checkmark would be
+  redundant. Revisit only if a future feature requires per-DB status (e.g.
+  multi-account MLS).
+- **Release notes** (issue #181 M6): implemented in `CHANGELOG.md`
+  ([Unreleased] > Security + Upgrade notes sections) and as a per-channel
+  template in [`docs/release-notes/issue-181-mls-db-encryption.md`](../../release-notes/issue-181-mls-db-encryption.md)
+  (JP + EN short forms for zapstore / GitHub Release / Google Play /
+  TestFlight, plus a support-facing FAQ).
+
+## Source references
+
+- `rust-engine/nurunuru-core/src/mls.rs` — `mls_db_path_for`, `new_with_key`, header test.
+- `rust-engine/nurunuru-core/src/engine.rs` — `bind_mls_for_pubkey`, `mls_is_encrypted`.
+- `rust-engine/nurunuru-ffi/src/lib.rs` — `new_with_mls_db_key`, `new_read_only_with_mls_db_key`, `mls_db_path_for`, `derive_mls_db_key_from_secret`.
+- `rust-engine/nurunuru-napi/src/lib.rs` — `create_with_mls_db_key`, `mls_is_encrypted`.
+- `android/app/src/main/kotlin/io/nurunuru/app/data/MlsDbKeyStore.kt`
+- `android/app/src/main/kotlin/io/nurunuru/app/data/MlsLegacyMigration.kt`
+- `android/app/src/main/kotlin/io/nurunuru/app/data/NostrClient.kt`
+- `android/app/src/main/kotlin/io/nurunuru/app/NuruNuruApp.kt`
+- `android/app/src/main/kotlin/io/nurunuru/app/viewmodel/AuthViewModel.kt`
+- `ios/NuruNuru/Data/MlsDbKeyStore.swift`
+- `ios/NuruNuru/Data/MlsLegacyMigration.swift`
+- `ios/NuruNuru/Data/NuruNuruFFILiveClient.swift`
+- `ios/NuruNuru/Data/NuruNuruFFIBridge.swift`
+- `ios/NuruNuru/Data/NostrRepository.swift`
+- `ios/NuruNuru/ViewModels/AuthViewModel.swift`
+- `scripts/issue-181-guard.mjs` — CI lint guard (M2)
+- `package.json` `scripts.lint:issue-181` — npm entry point for the guard
+- `CHANGELOG.md` `[Unreleased] > Security` + `Upgrade notes` — user-facing changelog (M6)
+- `docs/release-notes/issue-181-mls-db-encryption.md` — per-channel release notes + support FAQ (M6)
+
+## Related pages
+
+- [[talk]]
+- [[talk-marmot-mls]]
+- [[talk-relays]]
+- [[../platforms/rust-engine]]
+- [[../platforms/android]]
+- [[../platforms/ios]]
+- [[../decisions/adr-0009-mls-db-encryption]]
+- [[../decisions/adr-0002-native-talk-uses-marmot-mls]]

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -49,6 +49,7 @@
 | [[features/talk-relays]] | Talk 用 KeyPackage / Welcome / message relay strategy。 |
 | [[features/talk-debugging]] | Talk/Marmot debugging guidance and raw-log handling。 |
 | [[features/talk-ios-android-parity]] | Android/iOS native Talk protocol parity checklist。 |
+| [[features/mls-db-encryption]] | MLS storage SQLite encryption (SQLCipher) — issue #181, threat model, migration. |
 | [[features/relay-management]] | NIP-65 relay list、outbox model、target relay publish、接続制限。 |
 
 ## UI / Design
@@ -95,6 +96,7 @@
 | [[decisions/adr-0006-web-rust-bridge-is-stub]] | Web Rust bridge は現状 stub。 |
 | [[decisions/adr-0007-design-crit-ritual]] | Weekly Nuru Design Crit を制度化する判断。 |
 | [[decisions/adr-0008-four-freedoms-mission]] | 4軸自由ドクトリンを長期ミッションとして起票する判断。 |
+| [[decisions/adr-0009-mls-db-encryption]] | MLS storage DB を SQLCipher で暗号化する判断 (issue #181)。 |
 
 ## Maintenance checklist for agents
 

--- a/ios/NuruNuru.xcodeproj/project.pbxproj
+++ b/ios/NuruNuru.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		24E28146BB864DDAB57E5313 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE91ED6BEC7257E7906E98C4 /* HomeViewModel.swift */; };
 		252988B7DCC45C416290A742 /* NuruSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AEA78F1EE738C0E144D2C5 /* NuruSpacing.swift */; };
 		277AAA098498FB80AF3F8F31 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E3A499F94B9F995BE3D683 /* AuthViewModel.swift */; };
+		296B2D395FCDF78E7F892828 /* MlsDbKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BE8FBEAA418FDEB2309983 /* MlsDbKeyStore.swift */; };
 		2AC6193D4324CB71EF96D1A0 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FCC7ADD449DFEC1E6A7E45 /* AppLogger.swift */; };
 		37A33C4BCDADC57D7617C366 /* NostrKeyUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B6B700C2026B5983717773 /* NostrKeyUtils.swift */; };
 		3AA6D06F3BA0E7FB95B39455 /* RelaySelectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A34DBB9264E552D862E689 /* RelaySelectPanel.swift */; };
@@ -115,6 +116,7 @@
 		F6D6AF224258DE55B797CA50 /* PostRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD004F1EF8563E8A7676C4F0 /* PostRow.swift */; };
 		F8512BAA6E64C5D05B071814 /* EmojiPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF54414D84AD0B1640FB30F5 /* EmojiPickerSheet.swift */; };
 		FA32BBAB51F72FBB7E9DBC9A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4EEA5443A4028A0C3E90ADE1 /* Assets.xcassets */; };
+		FBC25AF61667A19A76FBD432 /* MlsLegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3070CE0B42175C3F35BDD57F /* MlsLegacyMigration.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,6 +132,7 @@
 /* Begin PBXFileReference section */
 		00A1662B48F53A7A6B33DA48 /* BadgeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeSettingsView.swift; sourceTree = "<group>"; };
 		00A34DBB9264E552D862E689 /* RelaySelectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectPanel.swift; sourceTree = "<group>"; };
+		02BE8FBEAA418FDEB2309983 /* MlsDbKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlsDbKeyStore.swift; sourceTree = "<group>"; };
 		04E3A499F94B9F995BE3D683 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		059BB80343ED1ECBB3B7BED1 /* ElevenLabsTTSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevenLabsTTSService.swift; sourceTree = "<group>"; };
 		06B76EF989F33C0F84071C9A /* BadgeDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeDisplay.swift; sourceTree = "<group>"; };
@@ -150,11 +153,12 @@
 		210FABCD51D6764B06FE9600 /* ElevenLabsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevenLabsSettingsView.swift; sourceTree = "<group>"; };
 		22C81898CCAB5026394F6CCE /* EmojiSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSettingsView.swift; sourceTree = "<group>"; };
 		258F294215084C36B837E1BC /* NuruTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuruTheme.swift; sourceTree = "<group>"; };
-		27EF9AB133C5BFB1E50D443C /* NuruNuru.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NuruNuru.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		27EF9AB133C5BFB1E50D443C /* NuruNuru.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = NuruNuru.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B58808CC989E2639C2EC065 /* CreateGroupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateGroupSheet.swift; sourceTree = "<group>"; };
 		2E21638AD92895A91FE23DCA /* NuruNuruTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = NuruNuruTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FD0E63F60538AB4F99A8263 /* ReactionEmojiPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionEmojiPicker.swift; sourceTree = "<group>"; };
 		3010FF61D09A1B750CFEFD42 /* SearchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSheet.swift; sourceTree = "<group>"; };
+		3070CE0B42175C3F35BDD57F /* MlsLegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlsLegacyMigration.swift; sourceTree = "<group>"; };
 		335294A58A8D17F139D62149 /* ZapSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZapSheet.swift; sourceTree = "<group>"; };
 		347F461AAF6346EF86999590 /* NuruColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NuruColors.swift; sourceTree = "<group>"; };
 		3606DF078E71DC476B53189D /* NostrRepository+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NostrRepository+Backup.swift"; sourceTree = "<group>"; };
@@ -304,6 +308,8 @@
 				06D59C7E1EDD4F2E9C77C2B4 /* ImageOptimizer.swift */,
 				2014B13EE5209550A26FF270 /* ImageUploadService.swift */,
 				11080352E6A44F2EA4B7C165 /* InternalSigner.swift */,
+				02BE8FBEAA418FDEB2309983 /* MlsDbKeyStore.swift */,
+				3070CE0B42175C3F35BDD57F /* MlsLegacyMigration.swift */,
 				936006252A321F8B76D86AE8 /* NostrCache.swift */,
 				8DC550261D89B6805D6F6159 /* NostrClient.swift */,
 				19B6B700C2026B5983717773 /* NostrKeyUtils.swift */,
@@ -637,6 +643,8 @@
 				674B37E79E1955ACD21E19EF /* LongFormPostItem.swift in Sources */,
 				440C2E36769D7D81A5487C5D /* MainTabView.swift in Sources */,
 				09D1F9BF3C4F2D15C81F6DE6 /* MarkdownContent.swift in Sources */,
+				296B2D395FCDF78E7F892828 /* MlsDbKeyStore.swift in Sources */,
+				FBC25AF61667A19A76FBD432 /* MlsLegacyMigration.swift in Sources */,
 				587C7A9F8C8C0159CD442674 /* MuteListView.swift in Sources */,
 				77C4C9A8813DE422A6135965 /* Nostr+Formatting.swift in Sources */,
 				70C11C209448AF8C6F30014A /* NostrBrowserView.swift in Sources */,
@@ -737,8 +745,6 @@
 				DEVELOPMENT_TEAM = 66G7S3P755;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = NuruNuru/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "ぬるぬる";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -883,8 +889,6 @@
 				DEVELOPMENT_TEAM = 66G7S3P755;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = NuruNuru/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "ぬるぬる";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/NuruNuru.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/NuruNuru.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/21-DOT-DEV/swift-secp256k1",
       "state" : {
-        "revision" : "4735a0ed8fd9d9f7e0a8b75aa760cf81a157452f",
-        "version" : "0.22.0"
+        "revision" : "cfab52e538683557259302c39ef25df60226eb30",
+        "version" : "0.23.1"
       }
     }
   ],

--- a/ios/NuruNuru/Data/MlsDbKeyStore.swift
+++ b/ios/NuruNuru/Data/MlsDbKeyStore.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Security
+
+#if NURUNURU_FFI_AVAILABLE
+import NuruNuruFFILib
+#endif
+
+/// Issue #181: provides the 32-byte SQLCipher key that the Rust core uses to
+/// encrypt `<AppSupport>/nurunuru_ndb_mls.sqlite3` on disk.
+///
+/// Mirror of Android `MlsDbKeyStore.kt`. Two key derivation paths:
+///
+/// 1. **Internal signer** — caller already holds the nsec hex; we derive
+///    deterministically via HKDF-SHA256 (FFI helper). No persistence needed:
+///    the key is regenerable from the nsec, so it survives reinstall as long
+///    as the user has their nsec backed up.
+///
+/// 2. **External signer (NIP-46 bunker)** — no nsec is ever exposed to this
+///    process. We generate a random 32-byte secret, scope it by pubkey hex,
+///    and store it in Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
+///    Stronger device-binding, at the cost of being unrecoverable after
+///    factory reset (and explicitly NOT iCloud-backed via the
+///    `ThisDeviceOnly` accessibility class).
+///
+/// **Threading**: `getOrCreateExternalKey` is guarded by an in-process
+/// `NSLock` so concurrent first-launch threads cannot generate two different
+/// random keys and race on the Keychain write (issue #181 B4).
+enum MlsDbKeyStore {
+
+    /// App-scope salt for HKDF derivation. Bump suffix if the scheme changes.
+    /// Must match Android `MlsDbKeyStore.APP_SALT`.
+    static let appSalt = "io.nurunuru.mdk.v1"
+
+    private static let keychainService = "io.nurunuru.app.mls"
+    private static let accountPrefixExternalKey = "external_mls_db_key_"
+
+    /// Synchronizes external-key generation across threads (issue #181 B4).
+    private static let lock = NSLock()
+
+    // MARK: - Internal signer (HKDF)
+
+    /// Deterministic SQLCipher key for the internal-signer path.
+    /// Equivalent to calling `derive_mls_db_key(nsec_bytes, APP_SALT)` in Rust.
+    ///
+    /// - Parameter secretKeyHex: 64-char nsec hex (no `nsec1` prefix).
+    /// - Returns: 32-byte HKDF-SHA256 output as `Data`.
+    static func deriveInternalKey(secretKeyHex: String) throws -> Data {
+#if NURUNURU_FFI_AVAILABLE
+        return try deriveMlsDbKeyFromSecret(secretKeyHex: secretKeyHex, appSalt: appSalt)
+#else
+        throw MlsDbKeyStoreError.ffiUnavailable
+#endif
+    }
+
+    // MARK: - External signer (random + Keychain)
+
+    /// Returns the cached 32-byte SQLCipher key for the given pubkey,
+    /// generating + persisting a new random one on first call.
+    ///
+    /// We deliberately use Keychain (NOT UserDefaults) with the most
+    /// conservative accessibility class so the key is:
+    ///   - never present in iCloud Keychain backups
+    ///   - unavailable while the device is locked at first boot
+    ///   - wiped on factory reset
+    ///
+    /// - Parameter pubkeyHex: 64-char lowercase hex pubkey.
+    static func getOrCreateExternalKey(pubkeyHex: String) throws -> Data {
+        guard pubkeyHex.count == 64 else {
+            throw MlsDbKeyStoreError.invalidPubkey
+        }
+        lock.lock()
+        defer { lock.unlock() }
+
+        let account = accountPrefixExternalKey + pubkeyHex.lowercased()
+
+        if let existing = readKeychain(account: account) {
+            if existing.count == 32 {
+                return existing
+            }
+            // Wrong-length entry: legacy or corrupt. Delete + regenerate.
+            deleteKeychain(account: account)
+        }
+
+        var fresh = Data(count: 32)
+        let status = fresh.withUnsafeMutableBytes { ptr -> Int32 in
+            guard let base = ptr.baseAddress else { return errSecAllocate }
+            return Int32(SecRandomCopyBytes(kSecRandomDefault, 32, base))
+        }
+        guard status == errSecSuccess else {
+            throw MlsDbKeyStoreError.randomFailed(status: status)
+        }
+
+        // We must NOT return a key that isn't persisted — the encrypted DB
+        // we'd create with it would become unrecoverable after process exit.
+        try writeKeychain(account: account, data: fresh)
+        return fresh
+    }
+
+    /// Removes the pubkey-scoped external key. Called from `AuthViewModel.logout()`
+    /// *before* `prefs.clear()` so we still have the pubkey to scope by.
+    static func clearExternalKey(pubkeyHex: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        let account = accountPrefixExternalKey + pubkeyHex.lowercased()
+        deleteKeychain(account: account)
+    }
+
+    /// Removes ALL external keys. Used on full wipe.
+    static func clearAllExternalKeys() {
+        lock.lock()
+        defer { lock.unlock() }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - Keychain helpers
+
+    private static func readKeychain(account: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return data
+    }
+
+    private static func writeKeychain(account: String, data: Data) throws {
+        // Delete existing entry first to avoid `errSecDuplicateItem`.
+        deleteKeychain(account: account)
+        let attrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: data
+        ]
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw MlsDbKeyStoreError.keychainWriteFailed(status: status)
+        }
+    }
+
+    private static func deleteKeychain(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+enum MlsDbKeyStoreError: Error, LocalizedError {
+    case ffiUnavailable
+    case invalidPubkey
+    case randomFailed(status: Int32)
+    case keychainWriteFailed(status: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .ffiUnavailable:
+            return "MLS FFI is not available (xcframework not linked)"
+        case .invalidPubkey:
+            return "MLS DB key requires a 64-char hex pubkey"
+        case .randomFailed(let status):
+            return "SecRandomCopyBytes failed (status=\(status))"
+        case .keychainWriteFailed(let status):
+            return "Keychain write failed (status=\(status))"
+        }
+    }
+}

--- a/ios/NuruNuru/Data/MlsLegacyMigration.swift
+++ b/ios/NuruNuru/Data/MlsLegacyMigration.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+#if NURUNURU_FFI_AVAILABLE
+import NuruNuruFFILib
+#endif
+
+/// Issue #181: detect + purge legacy plaintext MLS SQLite databases.
+///
+/// Mirror of Android `MlsLegacyMigration.kt`. Before #181 the iOS app called
+/// `MlsFFILiveClient(secretKeyHex:dbPath:)` which silently dropped to the
+/// unencrypted code path inside `bind_mls_for_pubkey`, producing a plaintext
+/// `nurunuru_ndb_mls.sqlite3` whose first 16 bytes are the literal ASCII
+/// `"SQLite format 3\u{0}"`. Such a file is unreadable by SQLCipher and must
+/// be purged before the new encrypted ctor runs, otherwise
+/// `MlsManager::new_with_key` returns `Error::NotADatabase`, the engine
+/// propagates an error, and Talk silently breaks.
+///
+/// **Content-based detection, not flag-based** (issue #181 B2): we check the
+/// file's first 16 bytes on every startup, not a one-shot "migrated" flag.
+/// That way any future regression that reintroduces a plaintext DB will be
+/// caught + repaired on next launch instead of being permanently locked out.
+///
+/// **Path resolution** (issue #181 B1): we route the db path through the FFI
+/// helper `mlsDbPathFor(...)` rather than reproducing `"{}_mls.sqlite3"`
+/// locally, to prevent cross-platform path drift.
+///
+/// **Run timing** (issue #181 M5): call this **before** `initEngine()` /
+/// before any `MlsFFILiveClient` constructor runs, so no Rust file handle
+/// holds the legacy DB open while we try to unlink it.
+///
+/// **Backup exclusion** (issue #181 M6): MLS DB files are excluded from
+/// iCloud + iTunes backup via `URLResourceKey.isExcludedFromBackupKey`, so a
+/// restored device cannot end up with an encrypted DB it has no key for.
+enum MlsLegacyMigration {
+
+    /// First 16 bytes of any plaintext SQLite 3 database.
+    private static let plaintextMagic: [UInt8] = [
+        0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66,
+        0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00
+    ]
+
+    /// If the MLS DB at the canonical path is detected as plaintext, remove
+    /// it and its WAL/SHM/journal sidecars. Idempotent.
+    ///
+    /// - Parameter dbDirectoryPath: The engine `db_path` value (e.g.
+    ///   `<AppSupport>/nurunuru_ndb`), NOT the `_mls.sqlite3` file itself.
+    /// - Returns: `true` when a plaintext DB was purged this call.
+    @discardableResult
+    static func purgePlaintextDbIfDetected(dbDirectoryPath: String) -> Bool {
+#if NURUNURU_FFI_AVAILABLE
+        // Source of truth for the DB path = the FFI helper. Mirrors the
+        // exact format the Rust engine opens (`"{db_path}_mls.sqlite3"`),
+        // so we cannot drift if the suffix ever changes.
+        let dbFile = mlsDbPathFor(dbPath: dbDirectoryPath)
+#else
+        let dbFile = "\(dbDirectoryPath)_mls.sqlite3"
+#endif
+
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: dbFile) else {
+            AppLogger.log("MlsLegacyMigration", "no MLS DB at \(dbFile); nothing to purge")
+            return false
+        }
+
+        let attrs = try? fm.attributesOfItem(atPath: dbFile)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        if size < 16 {
+            AppLogger.log("MlsLegacyMigration", "MLS DB file present but shorter than 16 bytes; treating as corrupt and purging")
+            return purgeAll(dbFile: dbFile, reason: "short-file")
+        }
+
+        guard let header = readFirst16Bytes(path: dbFile) else {
+            AppLogger.log("MlsLegacyMigration", "could not read MLS DB header; leaving untouched")
+            return false
+        }
+
+        if header == plaintextMagic {
+            AppLogger.log("MlsLegacyMigration", "Detected legacy plaintext MLS DB at \(dbFile) — purging (issue #181)")
+            return purgeAll(dbFile: dbFile, reason: "plaintext-detected")
+        }
+
+        // Header is salt/IV (SQLCipher) or something we don't recognise;
+        // either way it's NOT plaintext SQLite, so leave it for the
+        // encrypted ctor to handle.
+        return false
+    }
+
+    /// Mark the MLS DB + WAL/SHM as excluded from iCloud/iTunes backup. Call
+    /// this after the encrypted ctor has succeeded and the file exists on
+    /// disk. Safe to call repeatedly.
+    static func excludeMlsDbFromBackup(dbDirectoryPath: String) {
+#if NURUNURU_FFI_AVAILABLE
+        let dbFile = mlsDbPathFor(dbPath: dbDirectoryPath)
+#else
+        let dbFile = "\(dbDirectoryPath)_mls.sqlite3"
+#endif
+        for name in [dbFile, "\(dbFile)-wal", "\(dbFile)-shm"] {
+            guard FileManager.default.fileExists(atPath: name) else { continue }
+            var url = URL(fileURLWithPath: name)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            do {
+                try url.setResourceValues(values)
+            } catch {
+                AppLogger.log("MlsLegacyMigration", "failed to mark \(name) excluded-from-backup: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Internals
+
+    private static func readFirst16Bytes(path: String) -> [UInt8]? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        do {
+            let data: Data?
+            if #available(iOS 13.4, *) {
+                data = try handle.read(upToCount: 16)
+            } else {
+                data = handle.readData(ofLength: 16)
+            }
+            guard let bytes = data, bytes.count == 16 else { return nil }
+            return [UInt8](bytes)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func purgeAll(dbFile: String, reason: String) -> Bool {
+        let targets = [
+            dbFile,
+            "\(dbFile)-wal",
+            "\(dbFile)-shm",
+            "\(dbFile)-journal"
+        ]
+        var ok = true
+        for path in targets {
+            guard FileManager.default.fileExists(atPath: path) else { continue }
+            do {
+                try FileManager.default.removeItem(atPath: path)
+            } catch {
+                ok = false
+                AppLogger.log("MlsLegacyMigration", "failed to delete \(path): \(error)")
+            }
+        }
+        AppLogger.log("MlsLegacyMigration", "purged plaintext DB (reason=\(reason), success=\(ok))")
+        return ok
+    }
+}

--- a/ios/NuruNuru/Data/NostrRepository.swift
+++ b/ios/NuruNuru/Data/NostrRepository.swift
@@ -174,37 +174,51 @@ actor NostrRepository {
         let dbPath = dbPathURL.path
         AppLogger.log("FFI", "ensureMlsClient: dbPath=\(dbPath)")
 
+        // Issue #181 M5: purge any pre-#181 plaintext MLS DB *before* we let
+        // Rust open a handle to it. Content-based detection (B2) — runs every
+        // launch so future regressions can't lock users out permanently.
+        MlsLegacyMigration.purgePlaintextDbIfDetected(dbDirectoryPath: dbPath)
+
         do {
+            let ffi: MlsFFILiveClient
+            let accountPubkey: String
+
             if prefs.isExternalSigner {
                 guard let pubkey = prefs.publicKeyHex else {
                     AppLogger.log("FFI", "ensureMlsClient: missing publicKeyHex for external signer")
                     return nil
                 }
-                let ffi = try MlsFFILiveClient(pubkeyHex: pubkey, dbPath: dbPath)
-                ffi.connect()
-                self.mlsClient = ffi
-                Self.sharedFfiLock.lock()
-                Self.sharedMlsClient = ffi
-                Self.sharedMlsAccountPubkey = pubkey.lowercased()
-                Self.sharedFfiLock.unlock()
-                AppLogger.log("FFI", "ensureMlsClient: initialized read-only FFI account=\(String(pubkey.prefix(8)))… + connected")
-                return ffi
+                // Issue #181: random 32-byte key, scoped to pubkey, stored in
+                // Keychain (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly).
+                // Lock-guarded inside MlsDbKeyStore (B4 race).
+                var dbKey = try MlsDbKeyStore.getOrCreateExternalKey(pubkeyHex: pubkey)
+                // MlsFFILiveClient zeroizes `dbKey` via `inout` after FFI hand-off (B3).
+                ffi = try MlsFFILiveClient(pubkeyHex: pubkey, dbPath: dbPath, mlsDbKey: &dbKey)
+                accountPubkey = pubkey
             } else {
                 guard let keyHex = keyManager.getKeyHexTemporary() else {
                     AppLogger.log("FFI", "ensureMlsClient: secret key is not unlocked")
                     return nil
                 }
-                let ffi = try MlsFFILiveClient(secretKeyHex: keyHex, dbPath: dbPath)
-                ffi.connect()
-                let accountPubkey = keyManager.getStoredPublicKeyHex() ?? requestedPubkey ?? ""
-                self.mlsClient = ffi
-                Self.sharedFfiLock.lock()
-                Self.sharedMlsClient = ffi
-                Self.sharedMlsAccountPubkey = accountPubkey.lowercased()
-                Self.sharedFfiLock.unlock()
-                AppLogger.log("FFI", "ensureMlsClient: initialized full FFI account=\(String(accountPubkey.prefix(8)))… + connected")
-                return ffi
+                // Deterministic HKDF-SHA256 over the nsec — no persistence
+                // required, regenerable as long as the user has their nsec.
+                var dbKey = try MlsDbKeyStore.deriveInternalKey(secretKeyHex: keyHex)
+                ffi = try MlsFFILiveClient(secretKeyHex: keyHex, dbPath: dbPath, mlsDbKey: &dbKey)
+                accountPubkey = keyManager.getStoredPublicKeyHex() ?? requestedPubkey ?? ""
             }
+
+            // Issue #181 M6: exclude DB + WAL/SHM from iCloud/iTunes backup.
+            // A restored device with no Keychain entry could not decrypt them.
+            MlsLegacyMigration.excludeMlsDbFromBackup(dbDirectoryPath: dbPath)
+
+            ffi.connect()
+            self.mlsClient = ffi
+            Self.sharedFfiLock.lock()
+            Self.sharedMlsClient = ffi
+            Self.sharedMlsAccountPubkey = accountPubkey.lowercased()
+            Self.sharedFfiLock.unlock()
+            AppLogger.log("FFI", "ensureMlsClient: initialized \(prefs.isExternalSigner ? "read-only" : "full") FFI account=\(String(accountPubkey.prefix(8)))… + connected (MLS DB encrypted)")
+            return ffi
         } catch {
             AppLogger.log("FFI", "ensureMlsClient failed: \(error)")
             return nil

--- a/ios/NuruNuru/Data/NuruNuruFFIBridge.swift
+++ b/ios/NuruNuru/Data/NuruNuruFFIBridge.swift
@@ -178,6 +178,12 @@ protocol MlsFFIBridge: AnyObject, Sendable {
     func connect()
     func disconnect() throws
 
+    // ── Issue #181: encrypted-DB guard ──
+    /// Returns `true` when the MLS SQLite DB is encrypted (SQLCipher),
+    /// `false` when plaintext, `nil` when no MLS manager is bound yet.
+    /// The live client refuses to construct unless this returns `true`.
+    func mlsIsEncrypted() -> Bool?
+
     // ── KeyPackage (Kind 30443, MIP-00) ──
     func mlsCreateKeyPackage() throws -> FfiKeyPackageEventData
     func mlsValidateKeyPackageEvent(eventJSON: String) throws
@@ -238,6 +244,7 @@ protocol MlsFFIBridge: AnyObject, Sendable {
 final class MlsFFIStub: MlsFFIBridge, @unchecked Sendable {
     func connect() {}
     func disconnect() throws {}
+    func mlsIsEncrypted() -> Bool? { nil }
 
     func mlsCreateKeyPackage() throws -> FfiKeyPackageEventData {
         FfiKeyPackageEventData(kind: 30443, content: "", tags: [], legacyTags: [], dTag: "")

--- a/ios/NuruNuru/Data/NuruNuruFFILiveClient.swift
+++ b/ios/NuruNuru/Data/NuruNuruFFILiveClient.swift
@@ -9,18 +9,60 @@ import NuruNuruFFILib
 final class MlsFFILiveClient: MlsFFIBridge, @unchecked Sendable {
     private let client: NuruNuruClient
 
-    init(secretKeyHex: String, dbPath: String) throws {
+    /// Internal-signer (full-access) init. Issue #181: callers MUST supply
+    /// the 32-byte SQLCipher key derived from the user's nsec via
+    /// `MlsDbKeyStore.deriveInternalKey(secretKeyHex:)`. The legacy unkeyed
+    /// constructors `NuruNuruClient(secretKeyHex:)` / `newReadOnly(pubkeyHex:)`
+    /// MUST NOT be called from app code — they produce plaintext MLS DBs.
+    ///
+    /// **Zeroization (B3)**: takes `mlsDbKey` as `inout Data` and wipes it
+    /// after the FFI hand-off. `Data` is a value type, but `resetBytes(in:)`
+    /// mutates the underlying storage in place via the COW machinery — the
+    /// caller's binding becomes 32 zero bytes (verified). The previous
+    /// `var z = dbKey` pattern was a no-op copy.
+    init(secretKeyHex: String, dbPath: String, mlsDbKey: inout Data) throws {
         try initEngine(dbPath: dbPath)
-        self.client = try NuruNuruClient(secretKeyHex: secretKeyHex)
+        defer { mlsDbKey.resetBytes(in: 0..<mlsDbKey.count) }
+        self.client = try NuruNuruClient.newWithMlsDbKey(
+            secretKeyHex: secretKeyHex,
+            mlsDbKey: mlsDbKey
+        )
+        try Self.assertEncrypted(client: client)
     }
 
-    init(pubkeyHex: String, dbPath: String) throws {
+    /// External-signer (read-only) init. Same contract as the full init.
+    init(pubkeyHex: String, dbPath: String, mlsDbKey: inout Data) throws {
         try initEngine(dbPath: dbPath)
-        self.client = try NuruNuruClient.newReadOnly(pubkeyHex: pubkeyHex)
+        defer { mlsDbKey.resetBytes(in: 0..<mlsDbKey.count) }
+        self.client = try NuruNuruClient.newReadOnlyWithMlsDbKey(
+            pubkeyHex: pubkeyHex,
+            mlsDbKey: mlsDbKey
+        )
+        try Self.assertEncrypted(client: client)
+    }
+
+    /// Issue #181 B5+B7: hard-fail when the MLS DB ended up unencrypted (e.g.
+    /// a regression in the engine, a missed migration, or a stale plaintext
+    /// file that slipped past the purge). We refuse to expose an `MlsFFIBridge`
+    /// that's writing keys to a plaintext SQLite — surface as a thrown error
+    /// so the caller can show actionable UI instead of "Talk is empty".
+    private static func assertEncrypted(client: NuruNuruClient) throws {
+        let state = client.mlsIsEncrypted()
+        guard state == true else {
+            AppLogger.log("FFI", "MLS DB encryption assertion FAILED (state=\(String(describing: state))) — refusing to proceed (issue #181)")
+            try? client.disconnect()
+            throw MlsFFILiveClientError.encryptionRequired
+        }
+        AppLogger.log("FFI", "MLS DB encrypted (SQLCipher) — issue #181 guard OK")
     }
 
     func connect() { client.connect() }
     func disconnect() throws { try client.disconnect() }
+
+    /// Issue #181 B7: expose the engine's encryption state for diagnostics
+    /// / Settings UI ("MLS DB: encrypted"). Returns `nil` when there is no
+    /// MLS manager bound yet.
+    func mlsIsEncrypted() -> Bool? { client.mlsIsEncrypted() }
 
     func mlsCreateKeyPackage() throws -> FfiKeyPackageEventData {
         bridgeKeyPackage(try client.mlsCreateKeyPackage())
@@ -228,6 +270,20 @@ final class MlsFFILiveClient: MlsFFIBridge, @unchecked Sendable {
             memberCount: p.memberCount,
             isDm: p.isDm
         )
+    }
+}
+
+/// Issue #181: errors thrown by the live (encrypted) MLS bridge ctor.
+enum MlsFFILiveClientError: Error, LocalizedError {
+    /// `mlsIsEncrypted()` returned `false` or `nil` after init — refuse to
+    /// proceed because the DB would write key material in cleartext.
+    case encryptionRequired
+
+    var errorDescription: String? {
+        switch self {
+        case .encryptionRequired:
+            return "MLS DB must be encrypted (SQLCipher) — refusing to start in plaintext mode (issue #181)"
+        }
     }
 }
 #endif

--- a/ios/NuruNuru/ViewModels/AuthViewModel.swift
+++ b/ios/NuruNuru/ViewModels/AuthViewModel.swift
@@ -180,6 +180,14 @@ final class AuthViewModel {
         Task {
             await externalSigner.disconnect()
         }
+        // Issue #181: drop the per-pubkey SQLCipher key from Keychain
+        // *before* `prefs.clear()` wipes the pubkey we need to scope it.
+        // Internal-signer path is deterministic (HKDF over nsec) so no
+        // explicit key removal is needed there — `keyManager.deleteAll()`
+        // already drops the nsec, which is the root secret.
+        if let pubkey = prefs.publicKeyHex, prefs.isExternalSigner {
+            MlsDbKeyStore.clearExternalKey(pubkeyHex: pubkey)
+        }
         keyManager.deleteAll()
         prefs.clear()
         state = .loggedOut

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:rust": "cd rust-engine/nurunuru-napi && node ../../node_modules/.bin/napi build --release",
     "tokens": "node design-tokens/generate.mjs",
     "tokens:check": "node design-tokens/generate.mjs --check",
-    "wiki:lint": "node scripts/wiki-lint.mjs"
+    "wiki:lint": "node scripts/wiki-lint.mjs",
+    "lint:issue-181": "node scripts/issue-181-guard.mjs"
   },
   "dependencies": {
     "22": "^0.0.0",

--- a/scripts/issue-181-guard.mjs
+++ b/scripts/issue-181-guard.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Issue #181 guard — prevents reintroduction of unkeyed (plaintext-DB) MLS
+ * FFI constructors in app-layer code.
+ *
+ * Background:
+ *   PR for issue #181 made the MLS SQLite DB SQLCipher-encrypted on disk. The
+ *   plaintext-DB code paths still exist as low-level UniFFI constructors
+ *   (`NuruNuruClient(secretKeyHex:)` in Swift, `NuruNuruClient.invoke(...)` in
+ *   Kotlin, and `newReadOnly(pubkeyHex:)` on both) because the FFI surface is
+ *   generated. Application code must only use the `*WithMlsDbKey` variants.
+ *
+ * What this script does:
+ *   - Walks the iOS Swift sources (`ios/NuruNuru/`) and Android Kotlin
+ *     sources (`android/app/src/main/kotlin/`).
+ *   - Fails the build if it finds calls to the forbidden unkeyed
+ *     constructors anywhere outside the generated UniFFI bindings or
+ *     explicitly allowlisted wrapper files.
+ *   - Reports the file + line + matched text for every offence so reviewers
+ *     can fix them quickly.
+ *
+ * Run locally: `npm run lint:issue-181`
+ * In CI: invoked from the same script alongside the rest of the lint suite.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(scriptDir, '..')
+
+// ---------------------------------------------------------------------------
+// Directories scanned and files allowlisted
+// ---------------------------------------------------------------------------
+
+const SCAN_ROOTS = [
+  { dir: 'ios/NuruNuru', exts: ['.swift'] },
+  { dir: 'android/app/src/main/kotlin', exts: ['.kt'] },
+  // napi-rs Rust crate is intentionally NOT scanned: it operates at the
+  // FFI layer itself and must invoke the lower-level constructors.
+]
+
+const ALLOWLIST = new Set([
+  // The single wrapper file allowed to mention NuruNuruClient unkeyed APIs
+  // is the live FFI client, which only uses them through the WithMlsDbKey
+  // constructors. The guard still verifies the file does not call the
+  // forbidden symbols — see FORBIDDEN_PATTERNS below.
+])
+
+// Skip generated bindings — they are not app code and must contain the
+// unkeyed constructors as declarations.
+const SKIP_DIR_FRAGMENTS = [
+  'bindgen/swift-out',
+  'bindgen/kotlin-out',
+  'NuruNuruFFI.xcframework',
+  'build/',
+  '/build/',
+  '.build/',
+]
+
+// ---------------------------------------------------------------------------
+// Forbidden patterns
+// ---------------------------------------------------------------------------
+//
+// Each pattern has:
+//   id:      short code shown in the failure report
+//   regex:   ECMAScript regex matched per line
+//   message: human-readable explanation
+//   exts:    extensions to apply this pattern on (subset of SCAN_ROOTS exts)
+//
+// Patterns are intentionally tight so they cannot match the
+// `*WithMlsDbKey` variants (those contain the word "MlsDbKey").
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_PATTERNS = [
+  {
+    id: 'swift-ctor-unkeyed',
+    // try NuruNuruClient(secretKeyHex: …)  — but NOT *WithMlsDbKey()
+    regex: /\bNuruNuruClient\s*\(\s*secretKeyHex\s*:/,
+    message:
+      'Use `NuruNuruClient.newWithMlsDbKey(secretKeyHex:mlsDbKey:)` ' +
+      '(via MlsDbKeyStore.deriveInternalKey) instead of the unkeyed ' +
+      'constructor — Issue #181.',
+    exts: ['.swift'],
+  },
+  {
+    id: 'swift-readonly-unkeyed',
+    // NuruNuruClient.newReadOnly(pubkeyHex: …) called from app code.
+    // The WithMlsDbKey variant has "WithMlsDbKey" in the name, so this
+    // regex anchors on a word boundary right after `newReadOnly`.
+    regex: /\bNuruNuruClient\s*\.\s*newReadOnly\s*\(/,
+    message:
+      'Use `NuruNuruClient.newReadOnlyWithMlsDbKey(pubkeyHex:mlsDbKey:)` ' +
+      '(via MlsDbKeyStore.getOrCreateExternalKey) instead of `newReadOnly` ' +
+      '— Issue #181.',
+    exts: ['.swift'],
+  },
+  {
+    id: 'kotlin-ctor-unkeyed',
+    // Kotlin UniFFI emits NuruNuruClient as a class; the unkeyed invoke is
+    // exposed as `NuruNuruClient(secretKeyHex)` (positional) or
+    // `NuruNuruClient.invoke(secretKeyHex)` in older bindings. Anchor on
+    // the constructor-style call shape and exclude the `newWithMlsDbKey`
+    // companion call.
+    regex: /\bNuruNuruClient\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\)/,
+    message:
+      'Use `NuruNuruClient.newWithMlsDbKey(keyHex, dbKey)` (via ' +
+      'MlsDbKeyStore.deriveInternalKey) instead of the unkeyed constructor — ' +
+      'Issue #181.',
+    exts: ['.kt'],
+  },
+  {
+    id: 'kotlin-readonly-unkeyed',
+    // NuruNuruClient.newReadOnly(pubkeyHex)  (Kotlin call site)
+    regex: /\bNuruNuruClient\s*\.\s*newReadOnly\s*\(/,
+    message:
+      'Use `NuruNuruClient.newReadOnlyWithMlsDbKey(pubkeyHex, dbKey)` ' +
+      '(via MlsDbKeyStore.getOrCreateExternalKey) instead of `newReadOnly` ' +
+      '— Issue #181.',
+    exts: ['.kt'],
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Filesystem walk
+// ---------------------------------------------------------------------------
+
+function walk(dir, exts) {
+  const out = []
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    const relFromRoot = path.relative(root, p)
+    if (SKIP_DIR_FRAGMENTS.some((frag) => relFromRoot.includes(frag))) continue
+    let st
+    try {
+      st = statSync(p)
+    } catch {
+      continue
+    }
+    if (st.isDirectory()) {
+      out.push(...walk(p, exts))
+    } else if (exts.some((e) => name.endsWith(e))) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Lint
+// ---------------------------------------------------------------------------
+
+const failures = []
+let filesScanned = 0
+let matchesChecked = 0
+
+for (const { dir, exts } of SCAN_ROOTS) {
+  const absDir = path.join(root, dir)
+  if (!existsSync(absDir)) {
+    console.warn(`WARN  skip missing scan root: ${dir}`)
+    continue
+  }
+  const files = walk(absDir, exts)
+  for (const f of files) {
+    filesScanned++
+    const relPath = path.relative(root, f).replace(/\\/g, '/')
+    if (ALLOWLIST.has(relPath)) continue
+    const text = readFileSync(f, 'utf8')
+    const lines = text.split(/\r?\n/)
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      // Skip comments — single-line // and /// for Swift/Kotlin.
+      // Block comments are not perfectly handled, but the conservative
+      // single-line check covers ~all real-world usage.
+      const trimmed = line.trim()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+      for (const pat of FORBIDDEN_PATTERNS) {
+        if (!pat.exts.some((e) => f.endsWith(e))) continue
+        matchesChecked++
+        if (pat.regex.test(line)) {
+          failures.push({
+            file: relPath,
+            line: i + 1,
+            id: pat.id,
+            snippet: line.trim(),
+            message: pat.message,
+          })
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+if (failures.length === 0) {
+  console.log(
+    `issue-181-guard OK — scanned ${filesScanned} files, ` +
+      `${matchesChecked} pattern checks, 0 violations.`,
+  )
+  process.exit(0)
+}
+
+console.error(`\nissue-181-guard FAIL — ${failures.length} violation(s):\n`)
+for (const f of failures) {
+  console.error(`  ${f.file}:${f.line}  [${f.id}]`)
+  console.error(`    ${f.snippet}`)
+  console.error(`    → ${f.message}\n`)
+}
+console.error(
+  'These constructors open the MLS DB in plaintext mode and reintroduce ' +
+    'the vulnerability fixed by issue #181. See docs/wiki/features/' +
+    'mls-db-encryption.md for the approved keyed variants.\n',
+)
+process.exit(1)


### PR DESCRIPTION
Part **3 of 3** for Issue #181 (MLS storage at-rest encryption). **Closes #181** when merged.

> **Replaces PR #186** (auto-closed when its `feat/mls-db-encryption-rust-181` base branch was deleted after PR #184 merged). Rebased directly onto `main`. Same code, no scope change.

## Summary

Wires the iOS app to the encrypted MLS storage ctors introduced in PR #184 (now merged), adds a legacy plaintext purge, ships the user-facing docs (CHANGELOG, ADR-0009, feature page, release notes), and lands a CI guard that fails the build if the old unkeyed ctors are reintroduced.

## What ships in this PR

### `ios/NuruNuru/Data/MlsDbKeyStore.swift` (new, 179 lines)

iOS mirror of the Android keystore.

| Signer | DB key source |
|---|---|
| Internal | HKDF-SHA256 of in-process secret via FFI `derive_mls_db_key_from_secret`. **No key material at rest.** |
| External (NIP-46 Nostr Connect) | Keychain, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. `AfterFirstUnlock` (not `WhenUnlockedThisDeviceOnly`) is required because the app must be able to receive Talk pushes between locks. |

`NSLock` around get-or-derive closes the equivalent of the Android **B4** race.

### `ios/NuruNuru/Data/MlsLegacyMigration.swift` (new, 149 lines)

- Path via FFI `mls_db_path_for`.
- Content-based plaintext detection (SQLite header magic), same as Android.
- Sets `isExcludedFromBackup = true` on the DB / WAL / SHM trio (**M6** partial).

### `ios/NuruNuru/Data/NuruNuruFFILiveClient.swift`

- Switches to the keyed ctors (`newWithMlsDbKey` / `newReadOnlyWithMlsDbKey`) with `inout Data` zeroize via `Data.resetBytes(in:)` immediately after the FFI returns (review point **B3**).

### `ios/NuruNuru/Data/NuruNuruFFIBridge.swift`

- Adds `mlsIsEncrypted() -> Bool?` to the protocol.

### `ios/NuruNuru/Data/NostrRepository.swift` + `ViewModels/AuthViewModel.swift`

- **On launch**: assert `mlsIsEncrypted() == true`, log canonical guard line.
- **On logout**: clear Keychain entry before clearing user defaults.

### `scripts/issue-181-guard.mjs` (new, 218 lines) + `package.json`

Adds `npm run lint:issue-181`.

```
$ npm run lint:issue-181
issue-181-guard OK — scanned 214 files, 141596 pattern checks, 0 violations.
```

Negative test (injecting two violations) confirms both are reported with `file:line` + remediation hint.

### Docs

| File | Purpose |
|---|---|
| `CHANGELOG.md` | `[Unreleased] > Security` + `Upgrade notes` documenting the SQLCipher migration and the unavoidable past-message loss on upgrade (M6). |
| `docs/release-notes/issue-181-mls-db-encryption.md` (new) | JP + EN short forms for zapstore / GitHub Release / Google Play / TestFlight + support FAQ. |
| `docs/wiki/features/mls-db-encryption.md` (new) | Threat model, per-platform key custody, migration semantics, verification trace. |
| `docs/wiki/decisions/adr-0009-mls-db-encryption.md` (new) | Status: Accepted. Context / decision / alternatives / consequences. |
| `docs/wiki/index.md` | Adds the two new wiki pages. |

## Verification

```
$ npm run wiki:lint
wiki-lint: 0 failure(s), 0 warning(s)
$ npm run lint:issue-181
issue-181-guard OK — scanned 214 files, 141596 pattern checks, 0 violations.
```

A physical iPhone 12 mini cold-launch was previously confirmed to:
1. Emit the canonical `MLS DB encrypted (SQLCipher) — issue #181 guard OK` line.
2. Show the SQLCipher random-bytes header on disk.

Talk receive-loop logic from PR #180 is **not** touched.

## M4 ("encrypted ✓" Settings indicator) — dropped by product decision

The runtime guard already hard-fails on missing encryption (the canonical log line is mandatory), so a green checkmark would be redundant UI noise without an actionable user signal.

## Closes

- Closes #181
