### PR TITLE
fix(ios): exclude relay.nostr.bg in NostrClient to match deadRelays

### DIFF
--- a/ios/NuruNuru/Data/NostrClient.swift
+++ b/ios/NuruNuru/Data/NostrClient.swift
@@ -64,7 +64,15 @@ actor NostrClient {
     /// after failures, and failures place them in a long local cooldown to avoid
     /// creating load for relay operators. Users can still explicitly select them later.
     fileprivate static let operatorFriendlyCooldownRelays: Set<String> = ["relay.nostr.wirednet.jp", "relay.0xchat.com", "realy.westernbtc.com"]
-    fileprivate static let excludedRelays: Set<String> = ["wss://relay.nostr.band"]
+    /// Relays that must never be connected to from this layer.
+    /// MUST stay in sync with `NostrRepository.deadRelays`.
+    /// - `relay.nostr.band`: 503/429 on AUTH; no read access for non-paying clients.
+    /// - `relay.nostr.bg`: DNS/TLS handshake regularly times out after ~16s on real devices,
+    ///   producing repeated noisy reconnect logs with no functional benefit.
+    fileprivate static let excludedRelays: Set<String> = [
+        "wss://relay.nostr.band",
+        "wss://relay.nostr.bg",
+    ]
 
     fileprivate static func canonicalRelayUrl(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary

`NostrRepository.deadRelays` already lists both `relay.nostr.band` and `relay.nostr.bg` as known-dead, but `NostrClient.excludedRelays` only filtered out `relay.nostr.band`. As a result, `relay.nostr.bg` could still leak through to the connection layer whenever a relay URL list bypassed the repository-side filter (NIP-65 hints, user-configured relays, default fan-out paths that hit `NostrClient` directly).

## Evidence (real-device logs)

iPhone 12 mini (iOS 26.5) running build from #191:

- Repeated ~16-second TLS handshake timeouts against `relay.nostr.bg`
- Roughly **8 noisy log lines/min** with no functional benefit
- The same relay is treated as permanently dead one layer up in `NostrRepository`, so any outbound attempt is guaranteed to fail

## Change

```diff
- fileprivate static let excludedRelays: Set<String> = ["wss://relay.nostr.band"]
+ /// Relays that must never be connected to from this layer.
+ /// MUST stay in sync with `NostrRepository.deadRelays`.
+ /// - `relay.nostr.band`: 503/429 on AUTH; no read access for non-paying clients.
+ /// - `relay.nostr.bg`: DNS/TLS handshake regularly times out after ~16s on real devices,
+ ///   producing repeated noisy reconnect logs with no functional benefit.
+ fileprivate static let excludedRelays: Set<String> = [
+     "wss://relay.nostr.band",
+     "wss://relay.nostr.bg",
+ ]
```

The doc-comment also adds a sync requirement so the inconsistency cannot silently regress again.

## Risk

**None for reachable relays.** This only suppresses outbound connect attempts to a relay that was already classified as dead one layer up. No NIPs touched, no UX change, no token/wiki change required.

## Test plan

- [x] Code reads cleanly (1 file, +9 / -1)
- [x] Cross-checked: both lists now contain `{nostr.band, nostr.bg}` (see commit message)
- [ ] Real-device verification: after merge, capture a new Console.app sample from iPhone 12 mini and confirm zero `relay.nostr.bg` handshake-timeout lines in the same 67s window
- [ ] CI (wiki-lint, Vercel) green

## Out of scope (tracked separately)

- Triggering `deepCatchUpMlsGroup` hot path on Group A `a7e275e3…13f6` for live AC4 evidence on #190 — repair-button manual test, post-merge follow-up.