### PR TITLE
fix(security): resolve 9 Dependabot alerts (high 2 / moderate 2 / low 5)

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -2,6 +2,16 @@
 
 LLM Wiki の時系列ログです。追記専用として扱います。
 
+## [2026-05-23] sec | Dependabot 9 件 (high 2 / moderate 2 / low 5) 解消
+
+- GHSA-hc3c-63hc-2r9f **high** `libcrux-chacha20poly1305 0.0.7 → 0.0.8` — Overlong ciphertext buffer での panic を修正。`libcrux-aead` も 0.0.7→0.0.8 へ追従。
+- GHSA-82j2-j2ch-gfr8 **high** `rustls-webpki 0.103.9 → 0.103.13` — Malformed CRL BIT STRING による panic / DoS を修正。同時に GHSA-pwjx-qhcg-rvj4 (moderate, CRL distribution-point matching) と GHSA-965h-392x-2mh5 / GHSA-xgp8-3hg3-c2mh (low, URI / wildcard name constraints) も同バージョンで解消。
+- GHSA-qx2v-qp2m-jg93 **moderate** `postcss 8.4.38 → 8.5.15` (>=8.5.10) — `</style>` の unescape による XSS を修正。`next` 内部の transitive な 8.4.31 を抑止するため `overrides` を併用。
+- GHSA-cq8v-f236-94qc **low** `rand 0.8.5 → 0.8.6`, `0.9.2 → 0.9.3`, `0.10.0 → 0.10.1` — カスタムロガー + `rand::rng()` での unsoundness を修正。
+- 直接 `cargo update --precise 0.0.8` は `hpke-rs-libcrux 0.6.1` の `libcrux-aead = "0.0.7"` ピンに阻まれるため、`rust-engine/Cargo.toml` に `[patch.crates-io]` セクションを追加し `cryspen/hpke-rs` の `franziskus/bump-libcrux` PR (#154, rev 110d7477) を一時的に取り込んだ。upstream が 0.6.2 をリリースしたら patch を撤去予定。
+- 検証: `cargo check --workspace` 通過 / `cargo test -p nurunuru-core --no-run` 通過 / `npm run test` 189 passed / `npm audit` 0 vulnerabilities / `npm run tokens:check` in sync。
+- 変更ファイル: `package.json`, `package-lock.json`, `rust-engine/Cargo.toml`, `rust-engine/Cargo.lock`。Rust ソースコード (`lib.rs` 等) は無変更のため Android `.so` の再ビルドは次回リリース時で十分。
+
 ## [2026-05-23] perf | Send-button spinner reflects only the MLS send call (not pre-flight)
 
 - `TalkViewModel.sendMessage` on both iOS and Android no longer sets `sendingMessage = true` at the top of the function. The flag is now set immediately before the `repository.sendMlsMessage(...)` call so the spinner covers only the actual MLS network round-trip.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "autoprefixer": "10.4.19",
         "happy-dom": "^20.4.0",
         "jsdom": "^27.4.0",
-        "postcss": "8.4.38",
+        "postcss": "^8.5.10",
         "tailwindcss": "3.4.3",
         "typescript": "5.9.3",
         "vitest": "^4.0.18"
@@ -5180,34 +5180,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -5477,9 +5449,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5497,9 +5469,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -6604,35 +6576,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,12 @@
     "autoprefixer": "10.4.19",
     "happy-dom": "^20.4.0",
     "jsdom": "^27.4.0",
-    "postcss": "8.4.38",
+    "postcss": "^8.5.10",
     "tailwindcss": "3.4.3",
     "typescript": "5.9.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }

--- a/rust-engine/Cargo.lock
+++ b/rust-engine/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -384,7 +384,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -394,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -493,13 +504,13 @@ dependencies = [
 
 [[package]]
 name = "core-models"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+checksum = "1c406a8d3cdec6393dc8975b623d806ce2d586653c620f86f7fab2e043df1cb2"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.2",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -507,6 +518,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -594,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -755,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1168,15 +1188,13 @@ dependencies = [
 [[package]]
 name = "hpke-rs"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+source = "git+https://github.com/cryspen/hpke-rs.git?rev=110d7477d64317724581955d8975a68c34efbed6#110d7477d64317724581955d8975a68c34efbed6"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
- "rand_core 0.9.5",
  "serde",
  "subtle",
  "tls_codec",
@@ -1186,18 +1204,16 @@ dependencies = [
 [[package]]
 name = "hpke-rs-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+source = "git+https://github.com/cryspen/hpke-rs.git?rev=110d7477d64317724581955d8975a68c34efbed6#110d7477d64317724581955d8975a68c34efbed6"
 dependencies = [
- "rand_core 0.9.5",
+ "rand 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
+source = "git+https://github.com/cryspen/hpke-rs.git?rev=110d7477d64317724581955d8975a68c34efbed6#110d7477d64317724581955d8975a68c34efbed6"
 dependencies = [
  "hpke-rs-crypto",
  "libcrux-aead",
@@ -1205,7 +1221,7 @@ dependencies = [
  "libcrux-hkdf",
  "libcrux-kem",
  "libcrux-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_core 0.10.0",
  "zeroize",
@@ -1214,8 +1230,7 @@ dependencies = [
 [[package]]
 name = "hpke-rs-rust-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+source = "git+https://github.com/cryspen/hpke-rs.git?rev=110d7477d64317724581955d8975a68c34efbed6#110d7477d64317724581955d8975a68c34efbed6"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1224,7 +1239,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.10.0",
  "rand_core 0.6.4",
@@ -1499,9 +1514,9 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libcrux-aead"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13297ce29869a5c0edab0378837b0fc5f88bf99a843712d9201c3b1150b3b476"
+checksum = "17aa289bfe5761c63d8a92db4300f1032c06eb52087f54629411a7b043ace49c"
 dependencies = [
  "libcrux-aesgcm",
  "libcrux-chacha20poly1305",
@@ -1511,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-aesgcm"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f2a019dab4097585a7d4f5b9deebe46cd1e628b16a5bc4cb0ce35e1da334e6"
+checksum = "b934645bf352ac97dcd15d3320d112fb666e0d6e36d43f775fd56f798d8076ef"
 dependencies = [
  "libcrux-intrinsics",
  "libcrux-platform",
@@ -1523,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc08d044676af21343b32b988411fa98dbb5cf65a03c9df478ced221bbdfdb1b"
+checksum = "05bfc7607646722ec061c0a8d7c1b10d7caee9c53861744bad72ea575eaaa546"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1536,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-curve25519"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1e5fd8476a6ed609d24ef42aee5ab6f99f7c65d054f92412da9f499e423299"
+checksum = "ec083514a1a2b73d370d86b96d6f652c8bc2e28dc8977958bf5abf3ae10a1daa"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1548,29 +1563,29 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ecdh"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
+checksum = "6108d32c9596e8ebe935aa09e3b138c5802e633220a520e45b2fdb686bb5354b"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.2",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "libcrux-hacl-rs"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
+checksum = "66106db376ae249af86911aee048cf73ea1f394d6653026fc988dd22cf2a4ace"
 dependencies = [
  "libcrux-macros",
 ]
 
 [[package]]
 name = "libcrux-hkdf"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1a89ca0c89be3a268a921e47105fb7873badf7267f5e3ebf4ea46baedd73ef"
+checksum = "04a9af7770abf072a6ff90ce1ce131e816f1a27bdeba0fd70784aa5a498b76cd"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-hmac",
@@ -1579,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-hmac"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7a242707d65960770bd7e14e4f18a92bdf0b967777dd404887db8d087a643b"
+checksum = "d6445e62ee351a6c2ef6ebcb160bbc1cf0f0e38da689e62f5a2800e1cdba79c4"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1590,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
+checksum = "95b254f1797aecd888f76e9647e6bec7b4c26fb6d60a73fd9856e4a1e535c704"
 dependencies = [
  "core-models",
  "hax-lib",
@@ -1600,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-kem"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12631592f491d22fd1a176d32b2c6edfb673998fd3987e9d95f8fa79ad2a737b"
+checksum = "1bd3fe399a2dd37d27f0b9ea6f50f4ebe700cc59b042ca904fe8cebfbb008924"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-ecdh",
@@ -1610,7 +1625,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -1625,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ml-kem"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
+checksum = "e2679da115a0131b77bd68cb7021a5bf0c91dcac6f5201e697dc5f5f1b887eb6"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -1635,15 +1650,15 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.2",
+ "rand 0.10.1",
  "tls_codec",
 ]
 
 [[package]]
 name = "libcrux-p256"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4778ba25cb08bb8a96bd100e19ed9aecf78337198fd176036e21042b2dd99bc"
+checksum = "36ac9f1fa0a994e3ca583d998b6b4dafa73fc5b8d43dbfd3207b10fb2987fbaf"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1663,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02491808ee5b9db8cb65fad64ae0be812db64beef179d945c00c7787dc7dfcf9"
+checksum = "76a9144949845813a0b8787d08cbba47baabe59c83f3043e558e6e92385c40cc"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1682,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
+checksum = "cadb9239002b82f2ddad65ad8a4c67ca55db4eb51a039247c879a4af27eb214b"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1693,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
+checksum = "f314521d5115afff6466e35e82cecd3b3bdf1dbed80d69285769a0f51c74fcc7"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -1705,12 +1720,12 @@ dependencies = [
 
 [[package]]
 name = "libcrux-traits"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+checksum = "2613bf3dbf3670777bd6ecc3bcdd2d7a642663656b35ed2823529c4f1db0c9e9"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.2",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -1971,7 +1986,7 @@ dependencies = [
  "bip39",
  "bitcoin_hashes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.17",
  "hex",
@@ -2182,7 +2197,7 @@ dependencies = [
  "ed25519-dalek",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tls_codec",
 ]
@@ -2215,7 +2230,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
@@ -2371,7 +2386,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2383,7 +2398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2503,9 +2518,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2514,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2524,10 +2539,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.0",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
 ]
@@ -2760,7 +2776,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2788,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2873,7 +2889,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -2966,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2977,7 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3106,10 +3122,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3395,7 +3411,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3821,7 +3837,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust-engine/Cargo.toml
+++ b/rust-engine/Cargo.toml
@@ -38,3 +38,12 @@ lto = true
 codegen-units = 1
 opt-level = 3
 strip = true
+
+# Temporary patch to bump libcrux-aead/libcrux-chacha20poly1305 to 0.0.8
+# Fixes GHSA-hc3c-63hc-2r9f
+# TODO: Remove once cryspen/hpke-rs releases 0.6.2 (or whichever version) including the bump
+[patch.crates-io]
+hpke-rs = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
+hpke-rs-libcrux = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
+hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
+hpke-rs-crypto = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }


### PR DESCRIPTION
Closes the 9 open Dependabot alerts on  (https://github.com/tami1A84/null--nostr/security/dependabot).

## サマリー

| # | 重要度 | パッケージ | 旧 → 新 | アラート |
|---|---|---|---|---|
| 66 | **high** | libcrux-chacha20poly1305 | 0.0.7 → 0.0.8 | GHSA-hc3c-63hc-2r9f |
| 47 | **high** | rustls-webpki | 0.103.9 → 0.103.13 | GHSA-82j2-j2ch-gfr8 |
| 49 | moderate | postcss | 8.4.38 → 8.5.15 | GHSA-qx2v-qp2m-jg93 |
| 29 | moderate | rustls-webpki | (同上) | GHSA-pwjx-qhcg-rvj4 |
| 46 | low | rand 0.8.x | 0.8.5 → 0.8.6 | GHSA-cq8v-f236-94qc |
| 45 | low | rand 0.9.x | 0.9.2 → 0.9.3 | GHSA-cq8v-f236-94qc |
| 44 | low | rustls-webpki | (同上) | GHSA-965h-392x-2mh5 |
| 43 | low | rustls-webpki | (同上) | GHSA-xgp8-3hg3-c2mh |
| 41 | low | rand 0.10.x | 0.10.0 → 0.10.1 | GHSA-cq8v-f236-94qc |

## 実装メモ

### libcrux-chacha20poly1305 → 0.0.8 (high)
`cargo update --precise 0.0.8` は `hpke-rs-libcrux 0.6.1` の `libcrux-aead = "0.0.7"` ピンに阻まれて直接更新不可。
upstream の cryspen/hpke-rs#154 (`franziskus/bump-libcrux`) ブランチに `libcrux-aead = 0.0.8` への bump があるため、これを `[patch.crates-io]` で一時取り込み:

```toml
[patch.crates-io]
hpke-rs           = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
hpke-rs-libcrux   = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
hpke-rs-rust-crypto = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
hpke-rs-crypto    = { git = "https://github.com/cryspen/hpke-rs.git", rev = "110d7477d64317724581955d8975a68c34efbed6" }
```

**TODO:** cryspen/hpke-rs 0.6.2 (or later) がリリースされたら patch を撤去。

### rustls-webpki → 0.103.13 (high + moderate + low x2)
4 アラートをまとめて解消。

### postcss → 8.5.15 (moderate)
`devDependencies` の `^8.5.10` 更新に加え、`next` が内部で `8.4.31` を抱えているため `overrides` を併用:

```json
"overrides": { "postcss": "^8.5.10" }
```

### rand → 0.8.6 / 0.9.3 / 0.10.1 (low x3)
`cargo update -p rand@<version> --precise <new>` で 3 系統すべて更新。

## 検証

- `cargo check --workspace` ✅
- `cargo test -p nurunuru-core --no-run` ✅
- `npm run test` ✅ 189 passed / 7 skipped
- `npm audit` ✅ **0 vulnerabilities**
- `npm run tokens:check` ✅
- `npm run wiki:lint` ✅

## ソース変更なし

- Rust のソースコード (`lib.rs` 等) は無変更。
- Kotlin / Swift のソースコードも無変更。
- ⇒ Android `.so` の再生成や iOS `.xcframework` の再ビルドは **次回リリース時に行えば十分**。
- merge 後に Dependabot がリスキャンするまでアラート表示は残るが、修正は完了している。

## 変更ファイル

```
docs/wiki/log.md       |  10 +++
package-lock.json      |  71 ++-------------
package.json           |   5 +-
rust-engine/Cargo.lock | 170 ++++++++++++++++++++++++----------
rust-engine/Cargo.toml |   9 +++
```
