### PR TITLE
fix(login): 新規登録への導線が消える問題を修正

### DIFF
--- a/components/LoginScreen.js
+++ b/components/LoginScreen.js
@@ -309,8 +309,8 @@ export default function LoginScreen({ onLogin }) {
 
         {/* Login options */}
         <div className="space-y-4">
-          {(nosskeyHasKey || nosskeySupported) ? (
-            /* Passkey User: Prominent Passkey Login */
+          {nosskeyHasKey ? (
+            /* Returning Passkey User: Prominent Passkey Login */
             <div className="animate-slideUp space-y-4">
               <button
                 onClick={handleNosskeyLogin}
@@ -359,9 +359,20 @@ export default function LoginScreen({ onLogin }) {
                   </button>
                 </div>
               )}
+
+              {/* Always offer a path to registration, even for returning users
+                  whose passkey was removed from the device / password manager. */}
+              <div className="text-center pt-1">
+                <button
+                  onClick={() => setShowSignUpModal(true)}
+                  className="text-sm text-[var(--line-green)] hover:underline font-bold"
+                >
+                  アカウントをお持ちでない方は新規登録
+                </button>
+              </div>
             </div>
           ) : (
-            /* Non-Passkey User: Sign Up & Login */
+            /* New / Non-Passkey User: Sign Up & Login */
             <div className="animate-slideUp space-y-4">
               <div className="space-y-3">
                 <button


### PR DESCRIPTION
## 概要

ログイン画面（`components/LoginScreen.js`）で、**パスキー対応ブラウザでは「新規登録」への導線が表示されず、新規登録できない**問題を修正します。

nosskey-sdk のアップデート（0.1.2）とは無関係な独立の不具合修正で、`main` を基点にした別PRとして切り出しています（変更は `LoginScreen.js` のみ）。

## 問題

画面の分岐条件が以下になっていました：

```js
{(nosskeyHasKey || nosskeySupported) ? (
   /* パスキーでログイン（新規登録ボタンなし） */
) : (
   /* 新規登録 + ログイン */
)}
```

`nosskeySupported` は WebAuthn 対応（`!!window.PublicKeyCredential`）で `true` になるため、**Android Chrome 等のほぼ全モバイルブラウザで常に true**。結果、保存済み鍵を持たない新規ユーザーでも常に「パスキーでログイン」画面になり、**「新規登録」ボタンが出るブランチに到達できません**。

さらに、端末／Google パスワードマネージャーからパスキーを削除した場合でも、localStorage（`nurunuru_nosskey`）が残っていると `nosskeyHasKey` が true のままになり、ログインも新規登録もできない手詰まり状態になります。

## 修正

1. **分岐条件を `nosskeyHasKey` のみに変更** — 保存済み鍵を持つ復帰ユーザーだけがパスキーログイン優先画面になり、新規ユーザーは新規登録画面へ入れる。
2. **パスキーログイン画面にも「新規登録」ボタンを併置** — パスキーを削除した復帰ユーザーでも再登録へ到達できる。`SignUpModal` の描画は分岐の外にあるため両ブランチで正しく開きます。

## テスト観点

- [x] 新規ユーザー（鍵未保存・パスキー対応ブラウザ）で「新規登録」が表示される
- [x] 復帰ユーザー（`nurunuru_nosskey` あり）で「パスキーでログイン」＋「新規登録」リンクの両方が表示される

新規
<img width="780" height="1688" alt="shot-new-user" src="https://github.com/user-attachments/assets/6ad543d2-791d-4fe5-939f-d3a7dbd5c510" />

アカウントあり
<img width="780" height="1688" alt="shot-returning-user" src="https://github.com/user-attachments/assets/bfc412b2-fe9c-480c-aa07-249b6fa5b808" />


https://claude.ai/code/session_01UWogKzFZr8xp3uK7Jmibdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWogKzFZr8xp3uK7Jmibdu)_